### PR TITLE
Fix undersized reflection boxes on chore tracking log

### DIFF
--- a/hugo/content/merit-badges/family-life/guide/chore-tracking-log/index.md
+++ b/hugo/content/merit-badges/family-life/guide/chore-tracking-log/index.md
@@ -131,15 +131,15 @@ group_title: "Printable Worksheet"
 <div class="drg-worksheet__section">
   <h3 class="drg-worksheet__section-title">End-of-Month Reflection</h3>
 
-  <div class="drg-worksheet__writing-area" style="min-height: 4rem">
+  <div class="drg-worksheet__writing-area">
     Which chores did you do most consistently? Why?
   </div>
 
-  <div class="drg-worksheet__writing-area" style="min-height: 4rem">
+  <div class="drg-worksheet__writing-area">
     Which chores were hardest to keep up with? What got in the way?
   </div>
 
-  <div class="drg-worksheet__writing-area" style="min-height: 4rem">
+  <div class="drg-worksheet__writing-area">
     How did your chores affect your family this month?
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Remove inline `min-height: 4rem` overrides from the three end-of-month reflection writing areas on the Family Life chore tracking log
- The boxes now use the standard `12.5rem` height from the `.drg-worksheet__writing-area` class, giving Scouts enough room to write

## Test plan
- [ ] Visit `/merit-badges/family-life/guide/chore-tracking-log/` and confirm the three reflection boxes are appropriately sized
- [ ] Verify print layout still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)