### PR TITLE
Auth & identity: adult accounts, contextual role grants, scout profiles (#81)

### DIFF
--- a/app/e2e/fixtures/auth.fixture.ts
+++ b/app/e2e/fixtures/auth.fixture.ts
@@ -1,0 +1,78 @@
+import { test as base, type Page } from '@playwright/test';
+
+/**
+ * Auth-emulator fixtures for smoke e2e. Follows the doula-cooperative pattern:
+ * real auth against the Auth emulator, but ALL /api/* responses are stubbed via
+ * page.route() — no Functions/Firestore emulator involved.
+ */
+const AUTH_HOST = 'http://127.0.0.1:9099';
+const KEY = 'fake-api-key';
+const PASSWORD = 'password123';
+
+interface AuthFixtures {
+  /** Unique email per test so reruns don't collide in the emulator. */
+  verifiedEmail: string;
+  /** A page already signed in as a verified user, sitting on the home route. */
+  verifiedPage: Page;
+}
+
+export const test = base.extend<AuthFixtures>({
+  // eslint-disable-next-line no-empty-pattern -- Playwright requires the fixtures arg
+  verifiedEmail: async ({}, use, testInfo) => {
+    await use(`e2e-${testInfo.testId}-${testInfo.repeatEachIndex}@example.com`);
+  },
+
+  verifiedPage: async ({ page, request, verifiedEmail }, use) => {
+    // Create the account, then flip emailVerified via the emulator admin API
+    // ("Bearer owner" is the emulator's privileged token).
+    const signUp = await request.post(
+      `${AUTH_HOST}/identitytoolkit.googleapis.com/v1/accounts:signUp?key=${KEY}`,
+      { data: { email: verifiedEmail, password: PASSWORD, returnSecureToken: true } },
+    );
+    const { localId } = (await signUp.json()) as { localId: string };
+    await request.post(
+      `${AUTH_HOST}/identitytoolkit.googleapis.com/v1/accounts:update`,
+      {
+        headers: { authorization: 'Bearer owner' },
+        data: { localId, emailVerified: true },
+      },
+    );
+
+    // Stub the backend BEFORE navigating so the guard chain's bootstrap call
+    // resolves without a real API. needsConsent:false lets home render.
+    await page.route('**/api/users/me', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          user: {
+            uid: localId,
+            displayName: 'E2E Parent',
+            email: verifiedEmail,
+            phone: null,
+            acceptedTermsAt: '2026-01-01T00:00:00.000Z',
+            acceptedPrivacyAt: '2026-01-01T00:00:00.000Z',
+          },
+          needsConsent: false,
+        }),
+      }),
+    );
+    await page.route('**/api/health', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok' }),
+      }),
+    );
+
+    await page.goto('/sign-in');
+    await page.getByLabel('Email').fill(verifiedEmail);
+    await page.getByLabel('Password').fill(PASSWORD);
+    await page.getByRole('button', { name: 'Sign In' }).click();
+    await page.waitForURL('http://localhost:4200/');
+
+    await use(page);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/app/e2e/tests/auth-smoke.spec.ts
+++ b/app/e2e/tests/auth-smoke.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+
+test('unauthenticated visit to a protected route redirects to sign-in', async ({
+  page,
+}) => {
+  await page.goto('/');
+  await expect(page).toHaveURL(/\/sign-in$/);
+  await expect(page.getByRole('heading', { name: 'Sign In' })).toBeVisible();
+});
+
+test('email/password sign-up routes to the verify-email gate', async ({
+  page,
+}) => {
+  const email = `e2e-signup-${Date.now()}@example.com`;
+
+  await page.goto('/sign-in');
+  await page.getByRole('button', { name: 'Need an account? Sign up' }).click();
+  await page.getByLabel('Email').fill(email);
+  await page.getByLabel('Password').fill('password123');
+  await page.getByRole('button', { name: 'Sign Up' }).click();
+
+  // Unverified accounts are gated: the guard chain redirects to /verify-email.
+  await expect(page).toHaveURL(/\/verify-email$/);
+});

--- a/app/e2e/tests/home.spec.ts
+++ b/app/e2e/tests/home.spec.ts
@@ -1,18 +1,12 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../fixtures/auth.fixture';
 
-test('home page boots and shows API health status', async ({ page }) => {
-  await page.route('**/api/health', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ status: 'ok' }),
-    });
-  });
-
-  await page.goto('/');
-
+test('signed-in verified user lands on home with stubbed API', async ({
+  verifiedPage,
+}) => {
   await expect(
-    page.getByRole('heading', { name: 'Merit Badge University Platform' }),
+    verifiedPage.getByRole('heading', {
+      name: 'Merit Badge University Platform',
+    }),
   ).toBeVisible();
-  await expect(page.getByText('ok')).toBeVisible();
+  await expect(verifiedPage.getByText('ok')).toBeVisible();
 });

--- a/app/proxy.conf.json
+++ b/app/proxy.conf.json
@@ -3,5 +3,10 @@
     "target": "http://localhost:5001/merit-badge-university/us-east4/healthApi",
     "secure": false,
     "changeOrigin": true
+  },
+  "/api/users": {
+    "target": "http://localhost:5001/merit-badge-university/us-east4/usersApi",
+    "secure": false,
+    "changeOrigin": true
   }
 }

--- a/app/src/app/api-types/users-api.types.ts
+++ b/app/src/app/api-types/users-api.types.ts
@@ -1,0 +1,52 @@
+export type AgeBand = '10-11' | '12-13' | '14-15' | '16-17';
+
+/** Adult account, serialized for the client (Timestamps -> ISO strings). */
+export interface UserResponse {
+  uid: string;
+  displayName: string;
+  email: string;
+  phone: string | null;
+  acceptedTermsAt: string | null;
+  acceptedPrivacyAt: string | null;
+}
+
+/** Bootstrap result: the user doc plus whether onboarding/consent is still required. */
+export interface BootstrapResponse {
+  user: UserResponse;
+  needsConsent: boolean;
+}
+
+/** Onboarding submission: name + the combined Terms/Privacy acceptance. */
+export interface OnboardingRequest {
+  displayName: string;
+  acceptedTerms: true;
+}
+
+/** Scout profile serialized for the client. */
+export interface ScoutResponse {
+  scoutId: string;
+  firstName: string;
+  lastName: string;
+  unit: string | null;
+  council: string | null;
+  district: string | null;
+  ageBand: AgeBand | null;
+  bsaId: string | null;
+  accommodations: string | null;
+}
+
+export interface ScoutListResponse {
+  scouts: ScoutResponse[];
+}
+
+/** Create/update payload for a dependent scout profile. */
+export interface ScoutRequest {
+  firstName: string;
+  lastName: string;
+  unit?: string | null;
+  council?: string | null;
+  district?: string | null;
+  ageBand?: AgeBand | null;
+  bsaId?: string | null;
+  accommodations?: string | null;
+}

--- a/app/src/app/app.config.ts
+++ b/app/src/app/app.config.ts
@@ -1,4 +1,8 @@
-import { provideHttpClient, withFetch } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withFetch,
+  withInterceptors,
+} from '@angular/common/http';
 import {
   type ApplicationConfig,
   provideBrowserGlobalErrorListeners,
@@ -6,12 +10,13 @@ import {
 } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';
+import { authInterceptor } from './interceptors/auth.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZonelessChangeDetection(),
-    provideHttpClient(withFetch()),
+    provideHttpClient(withFetch(), withInterceptors([authInterceptor])),
     provideRouter(routes),
   ],
 };

--- a/app/src/app/app.routes.ts
+++ b/app/src/app/app.routes.ts
@@ -1,8 +1,32 @@
 import { type Routes } from '@angular/router';
+import {
+  requireAuth,
+  requireOnboarded,
+  requireUnauth,
+  requireVerified,
+} from './guards/auth-guards';
 
 export const routes: Routes = [
   {
+    path: 'sign-in',
+    canActivate: [requireUnauth],
+    loadComponent: () => import('./sign-in/sign-in').then((m) => m.SignIn),
+  },
+  {
+    path: 'verify-email',
+    canActivate: [requireAuth],
+    loadComponent: () =>
+      import('./verify-email/verify-email').then((m) => m.VerifyEmail),
+  },
+  {
+    path: 'onboarding',
+    canActivate: [requireAuth, requireVerified],
+    loadComponent: () =>
+      import('./onboarding/onboarding').then((m) => m.Onboarding),
+  },
+  {
     path: '',
+    canActivate: [requireAuth, requireVerified, requireOnboarded],
     loadComponent: () => import('./home/home').then((m) => m.Home),
   },
 ];

--- a/app/src/app/guards/auth-guards.spec.ts
+++ b/app/src/app/guards/auth-guards.spec.ts
@@ -1,0 +1,178 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  Router,
+  RouterOutlet,
+  provideRouter,
+  type Routes,
+} from '@angular/router';
+import { render, screen } from '@testing-library/angular/zoneless';
+import { describe, expect, it, vi } from 'vitest';
+import type { BootstrapResponse } from '../api-types/users-api.types';
+import { Auth } from '../services/auth';
+import {
+  requireAuth,
+  requireOnboarded,
+  requireUnauth,
+  requireVerified,
+} from './auth-guards';
+
+// The Angular unit-test system disallows vi.mock on relative imports, so we
+// mock at the firebase SDK boundary instead.
+const { mockAuth } = vi.hoisted(() => ({
+  mockAuth: {
+    currentUser: undefined as
+      | { uid: string; emailVerified: boolean }
+      | null
+      | undefined,
+    authStateReady: vi.fn<() => Promise<void>>(() => Promise.resolve()),
+  },
+}));
+
+vi.mock('firebase/app', () => ({ initializeApp: vi.fn(() => ({})) }));
+vi.mock('firebase/auth', () => ({
+  getAuth: () => mockAuth,
+  connectAuthEmulator: vi.fn(),
+}));
+vi.mock('firebase/firestore', () => ({
+  getFirestore: vi.fn(() => ({})),
+  connectFirestoreEmulator: vi.fn(),
+}));
+
+@Component({ selector: 'app-mock-home', template: '<h1>Home</h1>', changeDetection: ChangeDetectionStrategy.OnPush })
+class MockHome {}
+@Component({ selector: 'app-mock-sign-in', template: '<h1>Sign In</h1>', changeDetection: ChangeDetectionStrategy.OnPush })
+class MockSignIn {}
+@Component({ selector: 'app-mock-verify', template: '<h1>Verify</h1>', changeDetection: ChangeDetectionStrategy.OnPush })
+class MockVerify {}
+@Component({ selector: 'app-mock-onboarding', template: '<h1>Onboarding</h1>', changeDetection: ChangeDetectionStrategy.OnPush })
+class MockOnboarding {}
+@Component({ selector: 'app-mock-protected', template: '<h1>Protected</h1>', changeDetection: ChangeDetectionStrategy.OnPush })
+class MockProtected {}
+@Component({
+  template: '<router-outlet></router-outlet>',
+  imports: [RouterOutlet],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class MockApp {}
+
+const routes: Routes = [
+  { path: '', component: MockHome },
+  { path: 'sign-in', component: MockSignIn },
+  { path: 'verify-email', component: MockVerify },
+  { path: 'onboarding', component: MockOnboarding },
+  { path: 'protected', component: MockProtected, canActivate: [requireAuth] },
+  { path: 'verified-only', component: MockProtected, canActivate: [requireVerified] },
+  { path: 'guest-only', component: MockSignIn, canActivate: [requireUnauth] },
+  { path: 'onboarded-only', component: MockProtected, canActivate: [requireOnboarded] },
+];
+
+describe('auth route guards', () => {
+  describe('requireAuth', () => {
+    it('redirects an unauthenticated user to sign-in', async () => {
+      const { navigate } = await setup();
+      await navigate('/protected');
+      expect(screen.getByText('Sign In')).toBeVisible();
+    });
+
+    it('allows an authenticated user through', async () => {
+      const { navigate } = await setup({
+        currentUser: { uid: 'u1', emailVerified: true },
+      });
+      await navigate('/protected');
+      expect(screen.getByText('Protected')).toBeVisible();
+    });
+  });
+
+  describe('requireVerified', () => {
+    it('redirects an unverified user to verify-email', async () => {
+      const { navigate } = await setup({
+        currentUser: { uid: 'u1', emailVerified: false },
+      });
+      await navigate('/verified-only');
+      expect(screen.getByText('Verify')).toBeVisible();
+    });
+
+    it('allows a verified user through', async () => {
+      const { navigate } = await setup({
+        currentUser: { uid: 'u1', emailVerified: true },
+      });
+      await navigate('/verified-only');
+      expect(screen.getByText('Protected')).toBeVisible();
+    });
+  });
+
+  describe('requireUnauth', () => {
+    it('redirects an authenticated user to the app home', async () => {
+      const { navigate } = await setup({
+        currentUser: { uid: 'u1', emailVerified: true },
+      });
+      await navigate('/guest-only');
+      expect(screen.getByText('Home')).toBeVisible();
+    });
+
+    it('allows an unauthenticated user to reach the guest-only page', async () => {
+      const { navigate } = await setup();
+      await navigate('/guest-only');
+      expect(screen.getByText('Sign In')).toBeVisible();
+    });
+  });
+
+  describe('requireOnboarded', () => {
+    it('redirects to onboarding when consent is still needed', async () => {
+      const { navigate } = await setup({
+        bootstrap: { user: fakeUser(), needsConsent: true },
+      });
+      await navigate('/onboarded-only');
+      expect(screen.getByText('Onboarding')).toBeVisible();
+    });
+
+    it('allows a fully onboarded user through', async () => {
+      const { navigate } = await setup({
+        bootstrap: { user: fakeUser(), needsConsent: false },
+      });
+      await navigate('/onboarded-only');
+      expect(screen.getByText('Protected')).toBeVisible();
+    });
+  });
+});
+
+function fakeUser() {
+  return {
+    uid: 'u1',
+    displayName: 'Test',
+    email: 't@example.com',
+    phone: null,
+    acceptedTermsAt: null,
+    acceptedPrivacyAt: null,
+  };
+}
+
+interface SetupOptions {
+  currentUser?: { uid: string; emailVerified: boolean } | null;
+  bootstrap?: BootstrapResponse | undefined;
+}
+
+async function setup({ currentUser, bootstrap }: SetupOptions = {}) {
+  vi.spyOn(console, 'error').mockReturnValue(undefined);
+  mockAuth.currentUser = currentUser;
+  mockAuth.authStateReady = vi.fn(() => Promise.resolve());
+
+  const mockAuthService = {
+    ensureBootstrap: vi.fn(() => Promise.resolve(bootstrap)),
+  };
+
+  await render(MockApp, {
+    providers: [
+      provideRouter(routes),
+      { provide: Auth, useValue: mockAuthService },
+    ],
+  });
+
+  const router = TestBed.inject(Router);
+  const navigate = async (path: string) => {
+    await router.navigateByUrl(path);
+  };
+
+  return { navigate };
+}

--- a/app/src/app/guards/auth-guards.ts
+++ b/app/src/app/guards/auth-guards.ts
@@ -1,0 +1,42 @@
+import { inject } from '@angular/core';
+import { Router, type CanActivateFn } from '@angular/router';
+import { auth } from '../lib/firebase';
+import { Auth } from '../services/auth';
+
+/**
+ * Requires an authenticated user. Waits for Firebase to restore any persisted
+ * session first, so a hard refresh on a protected route doesn't bounce a
+ * signed-in user. Redirects to /sign-in otherwise.
+ */
+export const requireAuth: CanActivateFn = async () => {
+  const router = inject(Router);
+  await auth.authStateReady();
+  return auth.currentUser ? true : router.parseUrl('/sign-in');
+};
+
+/** Requires a verified email. Redirects to /verify-email otherwise. */
+export const requireVerified: CanActivateFn = async () => {
+  const router = inject(Router);
+  await auth.authStateReady();
+  const user = auth.currentUser;
+  if (!user) return router.parseUrl('/sign-in');
+  return user.emailVerified ? true : router.parseUrl('/verify-email');
+};
+
+/**
+ * Requires a completed onboarding/consent. Bootstraps the account and redirects
+ * to /onboarding when consent is still needed.
+ */
+export const requireOnboarded: CanActivateFn = async () => {
+  const router = inject(Router);
+  const authService = inject(Auth);
+  const bootstrap = await authService.ensureBootstrap();
+  return bootstrap?.needsConsent ? router.parseUrl('/onboarding') : true;
+};
+
+/** Inverse of requireAuth: sends already signed-in users to the app home. */
+export const requireUnauth: CanActivateFn = async () => {
+  const router = inject(Router);
+  await auth.authStateReady();
+  return auth.currentUser ? router.parseUrl('/') : true;
+};

--- a/app/src/app/interceptors/auth.interceptor.spec.ts
+++ b/app/src/app/interceptors/auth.interceptor.spec.ts
@@ -1,0 +1,151 @@
+import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { Router, provideRouter } from '@angular/router';
+import { describe, expect, it, vi } from 'vitest';
+import { authInterceptor } from './auth.interceptor';
+
+interface MockUser {
+  uid: string;
+  getIdToken: () => Promise<string>;
+}
+
+// The Angular unit-test system disallows vi.mock on relative imports, so we
+// mock at the firebase SDK boundary instead: getAuth returns our controllable
+// auth object, which lib/firebase then exports as the shared `auth` singleton.
+const { mockAuth, mockSignOut } = vi.hoisted(() => ({
+  mockAuth: { currentUser: undefined as MockUser | null | undefined },
+  mockSignOut: vi.fn<() => Promise<void>>(() => Promise.resolve()),
+}));
+
+vi.mock('firebase/app', () => ({ initializeApp: vi.fn(() => ({})) }));
+vi.mock('firebase/auth', () => ({
+  getAuth: () => mockAuth,
+  connectAuthEmulator: vi.fn(),
+  signOut: mockSignOut,
+}));
+vi.mock('firebase/firestore', () => ({
+  getFirestore: vi.fn(() => ({})),
+  connectFirestoreEmulator: vi.fn(),
+}));
+
+const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('authInterceptor', () => {
+  it('attaches a Bearer token to authenticated /api requests', async () => {
+    const { httpClient, httpTesting } = setup({
+      currentUser: { uid: 'u1', getIdToken: () => Promise.resolve('test-token') },
+    });
+
+    httpClient.get('/api/users/me').subscribe();
+    await flushMicrotasks();
+
+    const request = httpTesting.expectOne('/api/users/me');
+    expect(request.request.headers.get('Authorization')).toBe('Bearer test-token');
+    request.flush({});
+  });
+
+  it('leaves the request unmodified when no user is authenticated', async () => {
+    const { httpClient, httpTesting } = setup();
+
+    httpClient.get('/api/users/me').subscribe();
+    await flushMicrotasks();
+
+    const request = httpTesting.expectOne('/api/users/me');
+    expect(request.request.headers.has('Authorization')).toBe(false);
+    request.flush({});
+  });
+
+  it('does not touch requests to non-api hosts/paths', async () => {
+    const getIdToken = vi.fn();
+    const { httpClient, httpTesting } = setup({ currentUser: { uid: 'u1', getIdToken } });
+
+    httpClient.get('/assets/config.json').subscribe();
+    await flushMicrotasks();
+
+    const request = httpTesting.expectOne('/assets/config.json');
+    expect(request.request.headers.has('Authorization')).toBe(false);
+    expect(getIdToken).not.toHaveBeenCalled();
+    request.flush({});
+  });
+
+  it('signs out and redirects to sign-in on a 401 response', async () => {
+    const { httpClient, httpTesting, navigateSpy } = setup({
+      currentUser: { uid: 'u1', getIdToken: () => Promise.resolve('test-token') },
+    });
+
+    httpClient.get('/api/users/me').subscribe({ error: vi.fn() });
+    await flushMicrotasks();
+
+    httpTesting
+      .expectOne('/api/users/me')
+      .flush('unauthorized', { status: 401, statusText: 'Unauthorized' });
+    await flushMicrotasks();
+
+    expect(mockSignOut).toHaveBeenCalledOnce();
+    expect(navigateSpy).toHaveBeenCalledWith(['/sign-in']);
+  });
+
+  it('rethrows non-401 errors without signing out', async () => {
+    const { httpClient, httpTesting } = setup({
+      currentUser: { uid: 'u1', getIdToken: () => Promise.resolve('test-token') },
+    });
+    const errorHandler = vi.fn();
+
+    httpClient.get('/api/users/me').subscribe({ error: errorHandler });
+    await flushMicrotasks();
+
+    httpTesting
+      .expectOne('/api/users/me')
+      .flush('server error', { status: 500, statusText: 'Server Error' });
+    await flushMicrotasks();
+
+    expect(errorHandler).toHaveBeenCalledOnce();
+    expect(mockSignOut).not.toHaveBeenCalled();
+  });
+
+  it('proceeds without a token when token acquisition fails', async () => {
+    const { httpClient, httpTesting } = setup({
+      currentUser: {
+        uid: 'u1',
+        getIdToken: () => Promise.reject(new Error('network-request-failed')),
+      },
+    });
+
+    httpClient.get('/api/users/me').subscribe();
+    await flushMicrotasks();
+
+    const request = httpTesting.expectOne('/api/users/me');
+    expect(request.request.headers.has('Authorization')).toBe(false);
+    request.flush({});
+  });
+});
+
+interface SetupOptions {
+  currentUser?: MockUser | null;
+}
+
+function setup({ currentUser }: SetupOptions = {}) {
+  vi.spyOn(console, 'error').mockReturnValue(undefined);
+
+  mockAuth.currentUser = currentUser;
+  mockSignOut.mockReset();
+  mockSignOut.mockImplementation(() => Promise.resolve());
+
+  TestBed.configureTestingModule({
+    providers: [
+      provideHttpClient(withInterceptors([authInterceptor])),
+      provideHttpClientTesting(),
+      provideRouter([]),
+    ],
+  });
+
+  const httpClient = TestBed.inject(HttpClient);
+  const httpTesting = TestBed.inject(HttpTestingController);
+  const navigateSpy = vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+
+  return { httpClient, httpTesting, navigateSpy };
+}

--- a/app/src/app/interceptors/auth.interceptor.ts
+++ b/app/src/app/interceptors/auth.interceptor.ts
@@ -1,0 +1,66 @@
+import { type HttpErrorResponse, type HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { signOut } from 'firebase/auth';
+import { EMPTY, catchError, from, of, switchMap } from 'rxjs';
+import { auth } from '../lib/firebase';
+
+/**
+ * API paths that require authentication. Requests matching any of these get a
+ * Firebase ID token attached as a Bearer credential.
+ */
+const AUTHENTICATED_API_PATHS = ['/api/'];
+
+/**
+ * HTTP interceptor that manages Firebase Auth tokens on API requests.
+ *
+ * - Attaches the current user's ID token as a Bearer credential.
+ * - If no user is authenticated, the request proceeds without modification.
+ * - On a 401 response, signs the user out and redirects to /sign-in.
+ */
+export const authInterceptor: HttpInterceptorFn = (request, next) => {
+  const router = inject(Router);
+
+  const requiresAuth = AUTHENTICATED_API_PATHS.some((path) =>
+    request.url.includes(path),
+  );
+  if (!requiresAuth) {
+    return next(request);
+  }
+
+  return from(auth.currentUser?.getIdToken() ?? Promise.resolve(null)).pipe(
+    catchError((tokenError: unknown) => {
+      // Token acquisition failed (network error, revoked/expired token). Proceed
+      // without a token; the server responds 401 if auth is required, which the
+      // 401 handler below then catches.
+      console.error('Failed to acquire auth token for request:', {
+        url: request.url,
+        error:
+          tokenError instanceof Error ? tokenError.message : String(tokenError),
+      });
+      return of(null);
+    }),
+    switchMap((token) => {
+      if (!token) {
+        return next(request);
+      }
+      const authRequest = request.clone({
+        setHeaders: { Authorization: `Bearer ${token}` },
+      });
+      return next(authRequest);
+    }),
+    catchError((error: HttpErrorResponse) => {
+      if (error.status === 401) {
+        signOut(auth).then(
+          () => void router.navigate(['/sign-in']),
+          (signOutError: unknown) => {
+            console.error('Sign out after 401 failed:', signOutError);
+            void router.navigate(['/sign-in']);
+          },
+        );
+        return EMPTY;
+      }
+      throw error;
+    }),
+  );
+};

--- a/app/src/app/onboarding/onboarding.css
+++ b/app/src/app/onboarding/onboarding.css
@@ -1,0 +1,25 @@
+.onboarding {
+  max-width: 24rem;
+  margin: 3rem auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.onboarding__form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.onboarding__checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.onboarding__error {
+  color: #b00020;
+  font-size: 0.875rem;
+  margin: 0;
+}

--- a/app/src/app/onboarding/onboarding.html
+++ b/app/src/app/onboarding/onboarding.html
@@ -1,0 +1,32 @@
+<main class="onboarding">
+  <h1>Welcome</h1>
+  <p>Finish setting up your account.</p>
+
+  @if (errorMessage(); as error) {
+    <p class="onboarding__error" role="alert">{{ error }}</p>
+  }
+
+  <form [formGroup]="form" (ngSubmit)="onSubmit()" class="onboarding__form">
+    <label for="displayName">Your name</label>
+    <input id="displayName" type="text" formControlName="displayName" autocomplete="name" />
+    @if (form.get('displayName')?.invalid && form.get('displayName')?.touched) {
+      <p class="onboarding__error">Please enter your name.</p>
+    }
+
+    <label class="onboarding__checkbox">
+      <input type="checkbox" formControlName="acceptedTerms" />
+      I agree to the Terms and Privacy Policy
+    </label>
+    @if (form.get('acceptedTerms')?.invalid && form.get('acceptedTerms')?.touched) {
+      <p class="onboarding__error">You must accept the Terms and Privacy Policy.</p>
+    }
+
+    <button type="submit" [disabled]="isLoading()">
+      @if (isLoading()) {
+        Saving…
+      } @else {
+        Continue
+      }
+    </button>
+  </form>
+</main>

--- a/app/src/app/onboarding/onboarding.ts
+++ b/app/src/app/onboarding/onboarding.ts
@@ -1,0 +1,63 @@
+import { HttpClient } from '@angular/common/http';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import {
+  FormBuilder,
+  ReactiveFormsModule,
+  Validators,
+  type FormGroup,
+} from '@angular/forms';
+import { Router } from '@angular/router';
+import { firstValueFrom } from 'rxjs';
+import type {
+  OnboardingRequest,
+  UserResponse,
+} from '../api-types/users-api.types';
+import { Auth } from '../services/auth';
+
+@Component({
+  selector: 'app-onboarding',
+  imports: [ReactiveFormsModule],
+  templateUrl: './onboarding.html',
+  styleUrl: './onboarding.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class Onboarding {
+  private readonly auth = inject(Auth);
+  private readonly httpClient = inject(HttpClient);
+  private readonly router = inject(Router);
+  private readonly fb = inject(FormBuilder);
+
+  protected readonly isLoading = signal(false);
+  protected readonly errorMessage = signal('');
+
+  protected readonly form: FormGroup = this.fb.group({
+    displayName: [
+      this.auth.currentUser?.displayName ?? '',
+      [Validators.required],
+    ],
+    acceptedTerms: [false, [Validators.requiredTrue]],
+  });
+
+  protected async onSubmit(): Promise<void> {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    this.isLoading.set(true);
+    this.errorMessage.set('');
+    const displayName = (this.form.value.displayName as string).trim();
+    const body: OnboardingRequest = { displayName, acceptedTerms: true };
+
+    try {
+      await firstValueFrom(
+        this.httpClient.patch<UserResponse>('/api/users/me', body),
+      );
+      await this.router.navigate(['/']);
+    } catch {
+      this.errorMessage.set('Could not save your details. Please try again.');
+    } finally {
+      this.isLoading.set(false);
+    }
+  }
+}

--- a/app/src/app/services/auth.spec.ts
+++ b/app/src/app/services/auth.spec.ts
@@ -1,0 +1,99 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Auth } from './auth';
+
+interface MockUser {
+  uid: string;
+  email: string | null;
+  emailVerified: boolean;
+}
+
+// Mock at the firebase SDK boundary; lib/firebase re-exports getAuth()'s result
+// as the shared `auth` singleton the service consumes.
+const {
+  mockAuth,
+  mockSignIn,
+  mockCreateUser,
+  mockSendVerification,
+  mockOnIdTokenChanged,
+} = vi.hoisted(() => ({
+  mockAuth: { currentUser: undefined as MockUser | null | undefined },
+  mockSignIn: vi.fn(),
+  mockCreateUser: vi.fn(),
+  mockSendVerification: vi.fn<() => Promise<void>>(() => Promise.resolve()),
+  mockOnIdTokenChanged: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('firebase/app', () => ({ initializeApp: vi.fn(() => ({})) }));
+vi.mock('firebase/auth', () => ({
+  getAuth: () => mockAuth,
+  connectAuthEmulator: vi.fn(),
+  onIdTokenChanged: mockOnIdTokenChanged,
+  getIdTokenResult: vi.fn(),
+  signInWithEmailAndPassword: mockSignIn,
+  createUserWithEmailAndPassword: mockCreateUser,
+  sendEmailVerification: mockSendVerification,
+  signInWithPopup: vi.fn(),
+  signOut: vi.fn(() => Promise.resolve()),
+  GoogleAuthProvider: class {},
+}));
+vi.mock('firebase/firestore', () => ({
+  getFirestore: vi.fn(() => ({})),
+  connectFirestoreEmulator: vi.fn(),
+}));
+
+function makeService(): Auth {
+  TestBed.configureTestingModule({
+    providers: [
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      provideRouter([]),
+    ],
+  });
+  return TestBed.inject(Auth);
+}
+
+describe('Auth service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockReturnValue(undefined);
+    mockAuth.currentUser = null;
+  });
+
+  it('constructs and exposes the current user', () => {
+    mockAuth.currentUser = { uid: 'u1', email: 't@example.com', emailVerified: true };
+    const service = makeService();
+    expect(service.currentUser?.uid).toBe('u1');
+  });
+
+  it('signs in with email and password', async () => {
+    mockSignIn.mockResolvedValue({ user: { uid: 'u1' } });
+    const service = makeService();
+
+    await service.signInWithEmailPassword('t@example.com', 'password123');
+
+    expect(mockSignIn).toHaveBeenCalledWith(mockAuth, 't@example.com', 'password123');
+  });
+
+  it('translates firebase error codes into friendly messages', async () => {
+    mockSignIn.mockRejectedValue({ code: 'auth/invalid-credential' });
+    const service = makeService();
+
+    await expect(
+      service.signInWithEmailPassword('t@example.com', 'wrong'),
+    ).rejects.toThrow('Invalid email or password.');
+  });
+
+  it('sends a verification email on sign-up', async () => {
+    mockCreateUser.mockResolvedValue({ user: { uid: 'u2' } });
+    const service = makeService();
+
+    await service.signUpWithEmailPassword('new@example.com', 'password123');
+
+    expect(mockCreateUser).toHaveBeenCalledWith(mockAuth, 'new@example.com', 'password123');
+    expect(mockSendVerification).toHaveBeenCalledOnce();
+  });
+});

--- a/app/src/app/services/auth.ts
+++ b/app/src/app/services/auth.ts
@@ -1,0 +1,226 @@
+import { HttpClient } from '@angular/common/http';
+import {
+  computed,
+  effect,
+  inject,
+  resource,
+  Service,
+  signal,
+} from '@angular/core';
+import { Router } from '@angular/router';
+import {
+  createUserWithEmailAndPassword,
+  getIdTokenResult,
+  GoogleAuthProvider,
+  onIdTokenChanged,
+  sendEmailVerification,
+  signInWithEmailAndPassword,
+  signInWithPopup,
+  signOut,
+  type User,
+  type UserCredential,
+} from 'firebase/auth';
+import { firstValueFrom } from 'rxjs';
+import type { BootstrapResponse } from '../api-types/users-api.types';
+import { auth } from '../lib/firebase';
+
+// Shared auth error messages, translated from Firebase error codes.
+export const AUTH_ERROR_MESSAGES: Record<string, string> = {
+  'auth/email-already-in-use': 'An account with this email already exists.',
+  'auth/weak-password': 'Password should be at least 6 characters.',
+  'auth/invalid-email': 'Invalid email address.',
+  'auth/user-disabled': 'This account has been disabled.',
+  'auth/user-not-found': 'No account found with this email address.',
+  'auth/wrong-password': 'Incorrect password.',
+  'auth/invalid-credential': 'Invalid email or password.',
+  'auth/popup-closed-by-user': 'Sign-in was cancelled.',
+  'auth/too-many-requests':
+    'Too many failed attempts. Please try again later.',
+  'auth/network-request-failed':
+    'Network error. Please check your connection and try again.',
+  'auth/unknown-error':
+    'An error occurred during authentication. Please try again.',
+};
+
+@Service()
+export class Auth {
+  private readonly httpClient = inject(HttpClient);
+  private readonly router = inject(Router);
+
+  private readonly authUser = signal<User | null>(null);
+
+  readonly user = this.authUser.asReadonly();
+  readonly emailVerified = computed(
+    () => this.authUser()?.emailVerified ?? false,
+  );
+
+  // superAdmin custom claim, resolved from the ID token. Fails closed to false:
+  // an undefined value covers both "loading" and "claim fetch failed".
+  private readonly superAdminClaim = resource({
+    params: () => this.authUser(),
+    loader: async ({ params: user }) => {
+      if (!user) return false;
+      const result = await getIdTokenResult(user);
+      return result.claims['superAdmin'] === true;
+    },
+  });
+  readonly superAdmin = computed(() => this.superAdminClaim.value() ?? false);
+
+  // Bootstraps the account on the backend, but only once the user exists and
+  // has a verified email (the API rejects unverified sessions with 403).
+  readonly session = resource({
+    params: () =>
+      this.authUser() && this.emailVerified()
+        ? { uid: this.authUser()?.uid }
+        : undefined,
+    loader: () => this.postBootstrap(),
+  });
+
+  readonly needsConsent = computed(
+    () => this.session.value()?.needsConsent ?? false,
+  );
+  readonly sessionUser = computed(() => this.session.value()?.user);
+
+  constructor() {
+    effect((onCleanup) => {
+      // onIdTokenChanged re-emits on token refresh, keeping emailVerified and
+      // custom claims current (not just on sign-in/out).
+      const unsubscribe = onIdTokenChanged(
+        auth,
+        (user) => this.authUser.set(user),
+        (error) => console.error('Auth ID token listener error:', error),
+      );
+      onCleanup(unsubscribe);
+    });
+
+    effect(() => {
+      const error = this.superAdminClaim.error();
+      if (error) {
+        console.error(
+          'Failed to resolve superAdmin claim; treating user as non-super-admin:',
+          error,
+        );
+      }
+    });
+  }
+
+  get currentUser(): User | null {
+    return auth.currentUser;
+  }
+
+  private async postBootstrap(): Promise<BootstrapResponse> {
+    return await firstValueFrom(
+      this.httpClient.post<BootstrapResponse>('/api/users/me', {}),
+    );
+  }
+
+  /**
+   * Bootstraps the account and returns the response, used by route guards.
+   * Returns undefined when there is no verified user (nothing to bootstrap).
+   */
+  async ensureBootstrap(): Promise<BootstrapResponse | undefined> {
+    const user = auth.currentUser;
+    if (!user || !user.emailVerified) return undefined;
+    return await this.postBootstrap();
+  }
+
+  async signInWithGoogle(): Promise<UserCredential> {
+    try {
+      return await signInWithPopup(auth, new GoogleAuthProvider());
+    } catch (error) {
+      throw this.translateAuthError(error, 'signInWithGoogle');
+    }
+  }
+
+  async signInWithEmailPassword(
+    email: string,
+    password: string,
+  ): Promise<UserCredential> {
+    try {
+      return await signInWithEmailAndPassword(auth, email, password);
+    } catch (error) {
+      throw this.translateAuthError(error, 'signInWithEmailPassword');
+    }
+  }
+
+  async signUpWithEmailPassword(
+    email: string,
+    password: string,
+  ): Promise<UserCredential> {
+    try {
+      const credential = await createUserWithEmailAndPassword(
+        auth,
+        email,
+        password,
+      );
+      await sendEmailVerification(credential.user, {
+        url: `${globalThis.location.origin}/onboarding`,
+      });
+      return credential;
+    } catch (error) {
+      throw this.translateAuthError(error, 'signUpWithEmailPassword');
+    }
+  }
+
+  async resendEmailVerification(): Promise<void> {
+    const user = auth.currentUser;
+    if (!user) {
+      throw new Error('No authenticated user');
+    }
+    try {
+      await sendEmailVerification(user, {
+        url: `${globalThis.location.origin}/onboarding`,
+      });
+    } catch (error) {
+      throw this.translateAuthError(error, 'resendEmailVerification', {
+        uid: user.uid,
+      });
+    }
+  }
+
+  /** Reloads the current user, then forces a token refresh so listeners re-emit. */
+  async reloadUser(): Promise<void> {
+    const current = auth.currentUser;
+    if (!current) return;
+    try {
+      await current.reload();
+      await current.getIdToken(true);
+    } catch (error) {
+      console.error('Error reloading user:', error);
+      throw new Error('Failed to reload user data.', { cause: error });
+    }
+  }
+
+  async signOut(): Promise<void> {
+    try {
+      await signOut(auth);
+      void this.router.navigate(['/sign-in']);
+    } catch (error) {
+      console.error('Sign out failed:', {
+        uid: auth.currentUser?.uid,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw new Error('Failed to sign out. Please try again.', {
+        cause: error,
+      });
+    }
+  }
+
+  private translateAuthError(
+    error: unknown,
+    method: string,
+    context: Record<string, unknown> = {},
+  ): Error {
+    const errorCode = (error as { code?: string }).code ?? 'auth/unknown-error';
+    console.error(`Auth.${method} failed:`, {
+      method,
+      errorCode,
+      error: error instanceof Error ? error.message : String(error),
+      ...context,
+    });
+    return new Error(
+      AUTH_ERROR_MESSAGES[errorCode] ??
+        AUTH_ERROR_MESSAGES['auth/unknown-error'],
+    );
+  }
+}

--- a/app/src/app/sign-in/sign-in.css
+++ b/app/src/app/sign-in/sign-in.css
@@ -1,0 +1,27 @@
+.auth {
+  max-width: 22rem;
+  margin: 3rem auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.auth__form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.auth__error {
+  color: #b00020;
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+.auth__toggle,
+.auth__google {
+  background: none;
+  border: 1px solid currentColor;
+  padding: 0.5rem;
+  cursor: pointer;
+}

--- a/app/src/app/sign-in/sign-in.html
+++ b/app/src/app/sign-in/sign-in.html
@@ -1,0 +1,51 @@
+<main class="auth">
+  <h1>{{ mode() === 'sign-in' ? 'Sign In' : 'Create Account' }}</h1>
+
+  @if (errorMessage(); as error) {
+    <p class="auth__error" role="alert">{{ error }}</p>
+  }
+
+  <button
+    type="button"
+    class="auth__google"
+    (click)="onGoogle()"
+    [disabled]="isLoading()"
+  >
+    Continue with Google
+  </button>
+
+  <form [formGroup]="form" (ngSubmit)="onSubmit()" class="auth__form">
+    <label for="email">Email</label>
+    <input id="email" type="email" formControlName="email" autocomplete="email" />
+    @if (form.get('email')?.invalid && form.get('email')?.touched) {
+      <p class="auth__error">Enter a valid email address.</p>
+    }
+
+    <label for="password">Password</label>
+    <input
+      id="password"
+      type="password"
+      formControlName="password"
+      autocomplete="current-password"
+    />
+    @if (form.get('password')?.invalid && form.get('password')?.touched) {
+      <p class="auth__error">Password must be at least 6 characters.</p>
+    }
+
+    <button type="submit" [disabled]="isLoading()">
+      @if (isLoading()) {
+        Please wait…
+      } @else {
+        {{ mode() === 'sign-in' ? 'Sign In' : 'Sign Up' }}
+      }
+    </button>
+  </form>
+
+  <button type="button" class="auth__toggle" (click)="toggleMode()">
+    @if (mode() === 'sign-in') {
+      Need an account? Sign up
+    } @else {
+      Already have an account? Sign in
+    }
+  </button>
+</main>

--- a/app/src/app/sign-in/sign-in.ts
+++ b/app/src/app/sign-in/sign-in.ts
@@ -1,0 +1,74 @@
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import {
+  FormBuilder,
+  ReactiveFormsModule,
+  Validators,
+  type FormGroup,
+} from '@angular/forms';
+import { Router } from '@angular/router';
+import { Auth } from '../services/auth';
+
+@Component({
+  selector: 'app-sign-in',
+  imports: [ReactiveFormsModule],
+  templateUrl: './sign-in.html',
+  styleUrl: './sign-in.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SignIn {
+  private readonly auth = inject(Auth);
+  private readonly router = inject(Router);
+  private readonly fb = inject(FormBuilder);
+
+  protected readonly mode = signal<'sign-in' | 'sign-up'>('sign-in');
+  protected readonly isLoading = signal(false);
+  protected readonly errorMessage = signal('');
+
+  protected readonly form: FormGroup = this.fb.group({
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', [Validators.required, Validators.minLength(6)]],
+  });
+
+  protected toggleMode(): void {
+    this.mode.set(this.mode() === 'sign-in' ? 'sign-up' : 'sign-in');
+    this.errorMessage.set('');
+  }
+
+  protected async onSubmit(): Promise<void> {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    this.isLoading.set(true);
+    this.errorMessage.set('');
+    const { email, password } = this.form.value as {
+      email: string;
+      password: string;
+    };
+
+    try {
+      await (this.mode() === 'sign-in'
+        ? this.auth.signInWithEmailPassword(email, password)
+        : this.auth.signUpWithEmailPassword(email, password));
+      await this.router.navigate(['/']);
+    } catch (error) {
+      if (error instanceof Error) this.errorMessage.set(error.message);
+    } finally {
+      this.isLoading.set(false);
+    }
+  }
+
+  protected async onGoogle(): Promise<void> {
+    this.isLoading.set(true);
+    this.errorMessage.set('');
+    try {
+      await this.auth.signInWithGoogle();
+      await this.router.navigate(['/']);
+    } catch (error) {
+      if (error instanceof Error) this.errorMessage.set(error.message);
+    } finally {
+      this.isLoading.set(false);
+    }
+  }
+}

--- a/app/src/app/verify-email/verify-email.css
+++ b/app/src/app/verify-email/verify-email.css
@@ -1,0 +1,23 @@
+.verify {
+  max-width: 30rem;
+  margin: 3rem auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.verify__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.verify__error {
+  color: #b00020;
+  margin: 0;
+}
+
+.verify__message {
+  color: #1b5e20;
+  margin: 0;
+}

--- a/app/src/app/verify-email/verify-email.html
+++ b/app/src/app/verify-email/verify-email.html
@@ -1,0 +1,26 @@
+<main class="verify">
+  <h1>Verify your email</h1>
+  <p>
+    We sent a verification link
+    @if (email) {
+      to <strong>{{ email }}</strong>
+    }
+    . Open it, then come back and continue.
+  </p>
+
+  @if (message()) {
+    <p class="verify__message" role="status">{{ message() }}</p>
+  }
+  @if (errorMessage(); as error) {
+    <p class="verify__error" role="alert">{{ error }}</p>
+  }
+
+  <div class="verify__actions">
+    <button type="button" (click)="onResend()" [disabled]="isLoading()">
+      Resend email
+    </button>
+    <button type="button" (click)="onContinue()" [disabled]="isLoading()">
+      I've verified — continue
+    </button>
+  </div>
+</main>

--- a/app/src/app/verify-email/verify-email.ts
+++ b/app/src/app/verify-email/verify-email.ts
@@ -1,0 +1,50 @@
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { Router } from '@angular/router';
+import { Auth } from '../services/auth';
+
+@Component({
+  selector: 'app-verify-email',
+  templateUrl: './verify-email.html',
+  styleUrl: './verify-email.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class VerifyEmail {
+  private readonly auth = inject(Auth);
+  private readonly router = inject(Router);
+
+  protected readonly email = this.auth.currentUser?.email ?? '';
+  protected readonly isLoading = signal(false);
+  protected readonly message = signal('');
+  protected readonly errorMessage = signal('');
+
+  protected async onResend(): Promise<void> {
+    this.isLoading.set(true);
+    this.message.set('');
+    this.errorMessage.set('');
+    try {
+      await this.auth.resendEmailVerification();
+      this.message.set('Verification email sent. Check your inbox.');
+    } catch (error) {
+      if (error instanceof Error) this.errorMessage.set(error.message);
+    } finally {
+      this.isLoading.set(false);
+    }
+  }
+
+  protected async onContinue(): Promise<void> {
+    this.isLoading.set(true);
+    this.errorMessage.set('');
+    try {
+      await this.auth.reloadUser();
+      if (this.auth.currentUser?.emailVerified) {
+        await this.router.navigate(['/']);
+      } else {
+        this.errorMessage.set('Email is not verified yet. Please try again.');
+      }
+    } catch (error) {
+      if (error instanceof Error) this.errorMessage.set(error.message);
+    } finally {
+      this.isLoading.set(false);
+    }
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -98,6 +98,11 @@
           "region": "us-east4"
         },
         {
+          "source": "/api/users{,/**}",
+          "function": "usersApi",
+          "region": "us-east4"
+        },
+        {
           "source": "**",
           "destination": "/index.html"
         }

--- a/functions/eslint.config.js
+++ b/functions/eslint.config.js
@@ -4,7 +4,7 @@ import tseslint from "typescript-eslint";
 
 export default defineConfig([
   {
-    ignores: ["lib/**", "**/*.test.ts", "src/test-utils/**", "vitest.config.ts"],
+    ignores: ["lib/**"],
   },
   {
     files: ["**/*.ts"],
@@ -18,7 +18,9 @@ export default defineConfig([
     files: ["**/*.ts"],
     languageOptions: {
       parserOptions: {
-        projectService: true,
+        // tsconfig.test.json includes all of src (source + *.test.ts) with the
+        // same compiler options, so every linted .ts file is in the project.
+        project: ["./tsconfig.test.json"],
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -13,10 +13,10 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@types/bun": "^1.3.14",
         "eslint": "^10.4.0",
         "typescript": "^5.9.2",
-        "typescript-eslint": "^8.58.1",
-        "vitest": "^4.1.9"
+        "typescript-eslint": "^8.58.1"
       },
       "engines": {
         "node": "24"
@@ -44,40 +44,6 @@
       },
       "peerDependencies": {
         "elysia": ">= 1.4.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -556,13 +522,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@js-sdsl/ordered-map": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
@@ -572,25 +531,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
-      }
-    },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@nodable/entities": {
@@ -614,16 +554,6 @@
       "optional": true,
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@oxc-project/types": {
-      "version": "0.138.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
-      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -683,301 +613,12 @@
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
-      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
-      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
-      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
-      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
-      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
-      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
-      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
-      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
-      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
-      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
-      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
-      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
-      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
-      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
-      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
       "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
@@ -1014,17 +655,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -1035,23 +665,22 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/bun": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.14.tgz",
+      "integrity": "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "bun-types": "1.3.14"
+      }
+    },
     "node_modules/@types/caseless": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
       "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@types/chai": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
-      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/deep-eql": "*",
-        "assertion-error": "^2.0.1"
-      }
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
@@ -1070,13 +699,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/deep-eql": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
-      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -1459,119 +1081,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@vitest/expect": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
-      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.9",
-        "@vitest/utils": "4.1.9",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/mocker": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
-      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.1.9",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitest/pretty-format": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
-      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/runner": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
-      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "4.1.9",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/snapshot": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
-      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.9",
-        "@vitest/utils": "4.1.9",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/spy": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
-      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/utils": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
-      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.9",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -1702,16 +1211,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/assertion-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -1826,6 +1325,16 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/bun-types": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.14.tgz",
+      "integrity": "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -1862,16 +1371,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/chai": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
-      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/cliui": {
@@ -1942,13 +1441,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -2077,16 +1569,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2200,13 +1682,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/es-module-lexer": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
-      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -2410,16 +1885,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2461,16 +1926,6 @@
         "@sinclair/typebox": {
           "optional": true
         }
-      }
-    },
-    "node_modules/expect-type": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
-      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -2886,21 +2341,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -3573,279 +3013,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
-      }
-    },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/limiter": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
@@ -3950,16 +3117,6 @@
         "lru-cache": "6.0.0"
       }
     },
-    "node_modules/magic-string": {
-      "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4058,25 +3215,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -4163,20 +3301,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/obug": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
-      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/sxzz",
-        "https://opencollective.com/debug"
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/on-finished": {
@@ -4309,20 +3433,6 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
-    "node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/picomatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
@@ -4334,35 +3444,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.12",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -4522,40 +3603,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/rolldown": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
-      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oxc-project/types": "=0.138.0",
-        "@rolldown/pluginutils": "^1.0.0"
-      },
-      "bin": {
-        "rolldown": "bin/cli.mjs"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.4",
-        "@rolldown/binding-darwin-arm64": "1.1.4",
-        "@rolldown/binding-darwin-x64": "1.1.4",
-        "@rolldown/binding-freebsd-x64": "1.1.4",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
-        "@rolldown/binding-linux-arm64-musl": "1.1.4",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
-        "@rolldown/binding-linux-x64-gnu": "1.1.4",
-        "@rolldown/binding-linux-x64-musl": "1.1.4",
-        "@rolldown/binding-openharmony-arm64": "1.1.4",
-        "@rolldown/binding-wasm32-wasi": "1.1.4",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
-        "@rolldown/binding-win32-x64-msvc": "1.1.4"
       }
     },
     "node_modules/safe-buffer": {
@@ -4763,23 +3810,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/siginfo": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
-      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/srvx": {
       "version": "0.11.20",
       "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.20.tgz",
@@ -4792,13 +3822,6 @@
         "node": ">=20.16.0"
       }
     },
-    "node_modules/stackback": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
-      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -4807,13 +3830,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/stream-events": {
       "version": "1.0.5",
@@ -4954,23 +3970,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/tinybench": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
-      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tinyexec": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -4986,16 +3985,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -5194,174 +4183,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/vite": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
-      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.3",
-        "tinyglobby": "^0.2.17"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.3.0",
-        "esbuild": "^0.27.0 || ^0.28.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "@vitejs/devtools": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitest": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
-      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "4.1.9",
-        "@vitest/mocker": "4.1.9",
-        "@vitest/pretty-format": "4.1.9",
-        "@vitest/runner": "4.1.9",
-        "@vitest/snapshot": "4.1.9",
-        "@vitest/spy": "4.1.9",
-        "@vitest/utils": "4.1.9",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.9",
-        "@vitest/browser-preview": "4.1.9",
-        "@vitest/browser-webdriverio": "4.1.9",
-        "@vitest/coverage-istanbul": "4.1.9",
-        "@vitest/coverage-v8": "4.1.9",
-        "@vitest/ui": "4.1.9",
-        "happy-dom": "*",
-        "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        },
-        "vite": {
-          "optional": false
-        }
-      }
-    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -5426,23 +4247,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/why-is-node-running": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
-      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "siginfo": "^2.0.0",
-        "stackback": "0.0.2"
-      },
-      "bin": {
-        "why-is-node-running": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -8,8 +8,8 @@
     "typecheck": "tsc --noEmit",
     "typecheck:tests": "tsc --project tsconfig.test.json --noEmit",
     "serve": "npm run build && firebase emulators:start --only functions",
-    "test": "vitest run",
-    "test:watch": "vitest"
+    "test": "bun test",
+    "test:watch": "bun test --watch"
   },
   "engines": {
     "node": "24"
@@ -23,10 +23,10 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/bun": "^1.3.14",
     "eslint": "^10.4.0",
     "typescript": "^5.9.2",
-    "typescript-eslint": "^8.58.1",
-    "vitest": "^4.1.9"
+    "typescript-eslint": "^8.58.1"
   },
   "private": true
 }

--- a/functions/src/collections/role-grants.test.ts
+++ b/functions/src/collections/role-grants.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import { roleGrantId } from "./role-grants.js";
 
 describe("roleGrantId", () => {

--- a/functions/src/constants/error-ids.ts
+++ b/functions/src/constants/error-ids.ts
@@ -7,6 +7,12 @@ export const ERROR_IDS = {
   API_ADAPTER_MISSING_HOST: "api_adapter_missing_host",
   API_ADAPTER_RESPONSE_FAILED: "api_adapter_response_failed",
   API_HEADERS_ALREADY_SENT: "api_headers_already_sent",
+  API_AUTH_TOKEN_EXPIRED: "api_auth_token_expired",
+  API_AUTH_TOKEN_REVOKED: "api_auth_token_revoked",
+  API_AUTH_TOKEN_MALFORMED: "api_auth_token_malformed",
+  API_AUTH_TOKEN_WRONG_PROJECT: "api_auth_token_wrong_project",
+  API_AUTH_VERIFICATION_FAILED: "api_auth_verification_failed",
+  API_UNHANDLED_ROUTE_ERROR: "api_unhandled_route_error",
 } as const;
 
 export type ErrorId = (typeof ERROR_IDS)[keyof typeof ERROR_IDS];

--- a/functions/src/health-api/routes/health.test.ts
+++ b/functions/src/health-api/routes/health.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import { handleRequest } from "../../test-utils/handle-request.js";
 import { createApp } from "../app.js";
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -15,3 +15,14 @@ export const healthApi = onRequest(
     await handleHealthApi(request, response);
   },
 );
+
+export const usersApi = onRequest(
+  {
+    invoker: "public",
+    region: "us-east4",
+  },
+  async (request, response) => {
+    const { handleUsersApi } = await import("./users-api/handler.js");
+    await handleUsersApi(request, response);
+  },
+);

--- a/functions/src/scripts/set-initial-super-admin.ts
+++ b/functions/src/scripts/set-initial-super-admin.ts
@@ -1,0 +1,58 @@
+/**
+ * Grant the `superAdmin` custom claim to one account. Run once to bootstrap the
+ * first super-admin (#81 has no in-app super-admin management in v1). The target
+ * account must already exist in Firebase Auth (sign in once first).
+ *
+ * Emulator:
+ *   ADMIN_EMAIL=you@example.com bun run src/scripts/set-initial-super-admin.ts
+ * Production:
+ *   USE_EMULATOR=false ADMIN_EMAIL=you@example.com \
+ *     bun run src/scripts/set-initial-super-admin.ts
+ *   (requires GOOGLE_APPLICATION_CREDENTIALS for the project service account)
+ *
+ * The target's existing ID token is stale until they refresh (getIdToken(true))
+ * or sign out and back in.
+ */
+import { getApps, initializeApp } from "firebase-admin/app";
+import { getAuth } from "firebase-admin/auth";
+
+const PROJECT_ID = "merit-badge-university";
+const ADMIN_EMAIL = process.env["ADMIN_EMAIL"] ?? "";
+const ADMIN_UID = process.env["ADMIN_UID"] ?? "";
+const USE_EMULATOR = process.env["USE_EMULATOR"] !== "false";
+
+async function setInitialSuperAdmin(): Promise<void> {
+  if (!ADMIN_EMAIL && !ADMIN_UID) {
+    throw new Error("Set ADMIN_EMAIL (or ADMIN_UID) to the target account.");
+  }
+
+  if (USE_EMULATOR) {
+    process.env["FIREBASE_AUTH_EMULATOR_HOST"] ??= "localhost:9099";
+    process.env["GCLOUD_PROJECT"] ??= PROJECT_ID;
+    console.log("🔧 Using the Firebase Auth emulator");
+  }
+
+  if (getApps().length === 0) {
+    initializeApp({ projectId: PROJECT_ID });
+  }
+
+  const auth = getAuth();
+  const user = ADMIN_UID
+    ? await auth.getUser(ADMIN_UID)
+    : await auth.getUserByEmail(ADMIN_EMAIL);
+
+  const claims = { ...(user.customClaims ?? {}), superAdmin: true };
+  await auth.setCustomUserClaims(user.uid, claims);
+
+  const updated = await auth.getUser(user.uid);
+  console.log(`✅ superAdmin set for ${updated.email} (${updated.uid})`);
+  console.log("Custom claims:", updated.customClaims);
+}
+
+try {
+  await setInitialSuperAdmin();
+  process.exit(0);
+} catch (error) {
+  console.error("❌ Failed to set superAdmin claim:", error);
+  process.exit(1);
+}

--- a/functions/src/shared-api/errors/http-error.ts
+++ b/functions/src/shared-api/errors/http-error.ts
@@ -1,0 +1,61 @@
+/**
+ * HTTP errors with status codes, thrown by services/routes and mapped to
+ * responses by the shared Elysia `onError` handler.
+ *
+ * Ported from the doula-cooperative `functions` app, extended with an optional
+ * machine-readable `code` so the client can branch on specific conditions
+ * (e.g. EMAIL_NOT_VERIFIED) rather than string-matching messages.
+ */
+export class HttpError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+    /** Optional stable identifier for the client to branch on. */
+    public readonly code?: string,
+  ) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}
+
+/** 401 Unauthorized — authentication is required or has failed. */
+export class AuthError extends HttpError {
+  constructor(message: string, code?: string) {
+    super(message, 401, code);
+  }
+}
+
+/** 403 Forbidden — authenticated but lacking permission for this action. */
+export class ForbiddenError extends HttpError {
+  constructor(message: string, code?: string) {
+    super(message, 403, code);
+  }
+}
+
+/** 404 Not Found — resource does not exist. */
+export class NotFoundError extends HttpError {
+  constructor(message: string, code?: string) {
+    super(message, 404, code);
+  }
+}
+
+/** 400 Bad Request — invalid input or validation failure. */
+export class ValidationError extends HttpError {
+  constructor(message: string, code?: string) {
+    super(message, 400, code);
+  }
+}
+
+/** 409 Conflict — resource conflict (already exists, concurrent modification). */
+export class ConflictError extends HttpError {
+  constructor(message: string, code?: string) {
+    super(message, 409, code);
+  }
+}
+
+/** Machine-readable error codes shared with the client. */
+export const ERROR_CODES = {
+  EMAIL_NOT_VERIFIED: "EMAIL_NOT_VERIFIED",
+} as const;
+
+export type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES];

--- a/functions/src/shared-api/errors/on-error.ts
+++ b/functions/src/shared-api/errors/on-error.ts
@@ -1,0 +1,43 @@
+import { logger } from "firebase-functions/v2";
+import { ERROR_IDS } from "../../constants/error-ids.js";
+import { HttpError } from "./http-error.js";
+
+interface OnErrorContext {
+  /** Elysia error code — its own literals ("VALIDATION", …) or an HTTP number. */
+  code: string | number;
+  error: unknown;
+  set: { status?: number | string };
+}
+
+/**
+ * Shared Elysia `onError` handler. Maps thrown `HttpError`s to their status +
+ * a `{ error, code }` body, Elysia validation failures to 400, and anything
+ * else to a logged 500. Attach with `.onError(mapError)` on each API app.
+ */
+export function mapError({ code, error, set }: OnErrorContext) {
+  if (error instanceof HttpError) {
+    set.status = error.statusCode;
+    return { error: error.message, code: error.code };
+  }
+
+  if (code === "VALIDATION") {
+    set.status = 400;
+    return {
+      error: error instanceof Error ? error.message : "Invalid request",
+    };
+  }
+
+  if (code === "NOT_FOUND") {
+    set.status = 404;
+    return { error: "Not found" };
+  }
+
+  logger.error("Unhandled route error", {
+    errorId: ERROR_IDS.API_UNHANDLED_ROUTE_ERROR,
+    code,
+    errorMessage: error instanceof Error ? error.message : String(error),
+    errorStack: error instanceof Error ? error.stack : undefined,
+  });
+  set.status = 500;
+  return { error: "Internal server error" };
+}

--- a/functions/src/shared-api/plugins/require-auth.test.ts
+++ b/functions/src/shared-api/plugins/require-auth.test.ts
@@ -1,0 +1,65 @@
+import type { DecodedIdToken } from "firebase-admin/auth";
+import { describe, expect, it, mock } from "bun:test";
+import { ForbiddenError, HttpError } from "../errors/http-error.js";
+import { requireAuth, toVerifiedCaller } from "./require-auth.js";
+
+function decoded(overrides: Record<string, unknown> = {}): DecodedIdToken {
+  return {
+    uid: "uid-1",
+    email: "Parent@Example.com",
+    email_verified: true,
+    ...overrides,
+  } as DecodedIdToken;
+}
+
+function catchError(fn: () => unknown): unknown {
+  try {
+    fn();
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected the function to throw");
+}
+
+describe("toVerifiedCaller", () => {
+  it("lowercases email and defaults superAdmin to false", () => {
+    expect(toVerifiedCaller(decoded())).toEqual({
+      uid: "uid-1",
+      email: "parent@example.com",
+      emailVerified: true,
+      superAdmin: false,
+    });
+  });
+
+  it("surfaces the superAdmin custom claim", () => {
+    const caller = toVerifiedCaller(decoded({ superAdmin: true }));
+    expect(caller.superAdmin).toBe(true);
+  });
+
+  it("rejects an unverified email with EMAIL_NOT_VERIFIED (403)", () => {
+    const error = catchError(() =>
+      toVerifiedCaller(decoded({ email_verified: false })),
+    );
+    expect(error).toBeInstanceOf(ForbiddenError);
+    expect((error as ForbiddenError).statusCode).toBe(403);
+    expect((error as ForbiddenError).code).toBe("EMAIL_NOT_VERIFIED");
+  });
+
+  it("rejects a token with no email (401)", () => {
+    const error = catchError(() => toVerifiedCaller(decoded({ email: undefined })));
+    expect(error).toBeInstanceOf(HttpError);
+    expect((error as HttpError).statusCode).toBe(401);
+  });
+});
+
+describe("requireAuth resolver", () => {
+  it("verifies the Authorization header and returns a caller", async () => {
+    const verify = mock(async () => decoded());
+    const resolve = requireAuth(verify);
+
+    const result = await resolve({ headers: { authorization: "Bearer tok" } });
+
+    expect(verify).toHaveBeenCalledWith("Bearer tok");
+    expect(result.caller.uid).toBe("uid-1");
+  });
+});

--- a/functions/src/shared-api/plugins/require-auth.ts
+++ b/functions/src/shared-api/plugins/require-auth.ts
@@ -1,0 +1,55 @@
+import type { DecodedIdToken } from "firebase-admin/auth";
+import {
+  AuthError,
+  ERROR_CODES,
+  ForbiddenError,
+} from "../errors/http-error.js";
+import { verifyAuthToken } from "../services/auth/verify-token.js";
+import type { Caller } from "../types/caller.js";
+
+export type TokenVerifier = (
+  authorizationHeader: string | undefined,
+) => Promise<DecodedIdToken>;
+
+/**
+ * Build a Caller from a verified token, enforcing the "verified email for
+ * everyone" invariant (#81). Unverified sessions get a distinct 403 the client
+ * maps to the /verify-email gate.
+ */
+export function toVerifiedCaller(decoded: DecodedIdToken): Caller {
+  if (!decoded.email) {
+    throw new AuthError("Authenticated account has no email address");
+  }
+  if (decoded.email_verified !== true) {
+    throw new ForbiddenError(
+      "Email address is not verified",
+      ERROR_CODES.EMAIL_NOT_VERIFIED,
+    );
+  }
+  return {
+    uid: decoded.uid,
+    email: decoded.email.toLowerCase(),
+    emailVerified: true,
+    superAdmin: decoded["superAdmin"] === true,
+  };
+}
+
+/**
+ * Elysia `resolve` handler factory doing authentication ONLY. Apply it on the
+ * same instance as the routes so handlers can read `caller`:
+ *
+ *   new Elysia().resolve(requireAuth()).get("/me", ({ caller }) => ...)
+ *
+ * Authorization (role-in-scope checks) is separate — see services/authz. Inject
+ * a fake verifier in tests via the `verifyToken` argument.
+ */
+export function requireAuth(verifyToken: TokenVerifier = verifyAuthToken) {
+  return async ({
+    headers,
+  }: {
+    headers: Record<string, string | undefined>;
+  }): Promise<{ caller: Caller }> => {
+    const decoded = await verifyToken(headers["authorization"]);
+    return { caller: toVerifiedCaller(decoded) };
+  };
+}

--- a/functions/src/shared-api/services/auth/verify-token.test.ts
+++ b/functions/src/shared-api/services/auth/verify-token.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { AuthError } from "../../errors/http-error.js";
+
+const verifyIdToken = mock();
+
+mock.module("firebase-admin/auth", () => ({
+  getAuth: () => ({ verifyIdToken }),
+}));
+mock.module("firebase-functions/v2", () => ({
+  logger: { warn: mock(), error: mock(), info: mock() },
+}));
+
+const { verifyAuthToken } = await import("./verify-token.js");
+
+describe("verifyAuthToken", () => {
+  beforeEach(() => {
+    verifyIdToken.mockReset();
+  });
+
+  it("rejects a missing Authorization header", async () => {
+    await expect(verifyAuthToken(undefined)).rejects.toBeInstanceOf(AuthError);
+  });
+
+  it("rejects a non-Bearer scheme", async () => {
+    await expect(verifyAuthToken("Basic abc")).rejects.toBeInstanceOf(
+      AuthError,
+    );
+  });
+
+  it("rejects an empty Bearer token", async () => {
+    await expect(verifyAuthToken("Bearer   ")).rejects.toBeInstanceOf(
+      AuthError,
+    );
+  });
+
+  it("returns the decoded token for a valid Bearer token", async () => {
+    verifyIdToken.mockResolvedValue({ uid: "u1", email: "a@b.com" });
+    const decoded = await verifyAuthToken("Bearer good-token");
+    expect(decoded.uid).toBe("u1");
+    expect(decoded.email).toBe("a@b.com");
+    expect(verifyIdToken).toHaveBeenCalledWith("good-token");
+  });
+
+  it("maps an expired token to a friendly AuthError", async () => {
+    verifyIdToken.mockRejectedValue({
+      code: "auth/id-token-expired",
+      message: "expired",
+    });
+    await expect(verifyAuthToken("Bearer t")).rejects.toThrow(/expired/i);
+  });
+
+  it("maps an unknown Firebase error to a generic AuthError", async () => {
+    verifyIdToken.mockRejectedValue({ code: "auth/weird", message: "x" });
+    await expect(verifyAuthToken("Bearer t")).rejects.toBeInstanceOf(AuthError);
+  });
+});

--- a/functions/src/shared-api/services/auth/verify-token.ts
+++ b/functions/src/shared-api/services/auth/verify-token.ts
@@ -1,0 +1,108 @@
+import { getAuth, type DecodedIdToken } from "firebase-admin/auth";
+import { logger } from "firebase-functions/v2";
+import { ERROR_IDS } from "../../../constants/error-ids.js";
+import { AuthError } from "../../errors/http-error.js";
+
+/** Firebase Auth error shape (has a string `code`). */
+interface FirebaseAuthError {
+  code?: string;
+  message: string;
+}
+
+function isFirebaseAuthError(error: unknown): error is FirebaseAuthError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof (error as FirebaseAuthError).code === "string"
+  );
+}
+
+/**
+ * Extract and verify a Firebase ID token from an Authorization header.
+ * Local cryptographic verification (no network round-trip except on key rotation).
+ *
+ * @throws AuthError (401) if the header is missing/malformed or the token is
+ *   missing, expired, revoked, or otherwise invalid.
+ */
+export async function verifyAuthToken(
+  authorizationHeader: string | undefined,
+): Promise<DecodedIdToken> {
+  if (!authorizationHeader) {
+    throw new AuthError("Missing Authorization header");
+  }
+
+  if (!authorizationHeader.startsWith("Bearer ")) {
+    throw new AuthError("Authorization header must use the Bearer scheme");
+  }
+
+  const token = authorizationHeader.slice("Bearer ".length).trim();
+
+  if (token.length === 0) {
+    throw new AuthError("Missing auth token");
+  }
+
+  try {
+    return await getAuth().verifyIdToken(token);
+  } catch (error) {
+    if (isFirebaseAuthError(error)) {
+      switch (error.code) {
+        case "auth/id-token-expired":
+        case "auth/session-cookie-expired": {
+          logger.warn("Expired auth token", {
+            errorId: ERROR_IDS.API_AUTH_TOKEN_EXPIRED,
+            errorCode: error.code,
+          });
+          throw new AuthError("Your session has expired. Please sign in again.");
+        }
+        case "auth/id-token-revoked":
+        case "auth/session-cookie-revoked": {
+          logger.warn("Revoked auth token", {
+            errorId: ERROR_IDS.API_AUTH_TOKEN_REVOKED,
+            errorCode: error.code,
+          });
+          throw new AuthError(
+            "Your session has been revoked. Please sign in again.",
+          );
+        }
+        case "auth/argument-error":
+        case "auth/invalid-id-token": {
+          logger.warn("Malformed auth token", {
+            errorId: ERROR_IDS.API_AUTH_TOKEN_MALFORMED,
+            errorCode: error.code,
+          });
+          throw new AuthError("Invalid authentication token format");
+        }
+        case "auth/project-not-found":
+        case "auth/invalid-credential": {
+          logger.error("Auth token from wrong project or invalid credentials", {
+            errorId: ERROR_IDS.API_AUTH_TOKEN_WRONG_PROJECT,
+            errorCode: error.code,
+            errorMessage: error.message,
+          });
+          throw new AuthError(
+            "Authentication token is not valid for this application",
+          );
+        }
+        default: {
+          logger.error("Firebase Auth verification failed", {
+            errorId: ERROR_IDS.API_AUTH_VERIFICATION_FAILED,
+            errorCode: error.code,
+            errorMessage: error.message,
+          });
+          throw new AuthError(
+            "Unable to verify authentication token. Please try again.",
+          );
+        }
+      }
+    }
+
+    logger.error("Auth verification failed with non-Firebase error", {
+      errorId: ERROR_IDS.API_AUTH_VERIFICATION_FAILED,
+      errorType: error?.constructor?.name,
+    });
+    throw new AuthError(
+      "Unable to verify authentication token. Please try again.",
+    );
+  }
+}

--- a/functions/src/shared-api/services/authz/assertions.test.ts
+++ b/functions/src/shared-api/services/authz/assertions.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, mock } from "bun:test";
+import { ForbiddenError } from "../../errors/http-error.js";
+import type { Caller } from "../../types/caller.js";
+import {
+  assertChancellorOf,
+  assertCounselorOf,
+  assertOwnsScout,
+  requireSuperAdmin,
+} from "./assertions.js";
+import type { GrantQuery, RoleGrantsReader } from "./role-grants-reader.js";
+import type { ScoutOwnershipReader } from "./scout-ownership-reader.js";
+
+function caller(overrides: Partial<Caller> = {}): Caller {
+  return {
+    uid: "u1",
+    email: "u1@example.com",
+    emailVerified: true,
+    superAdmin: false,
+    ...overrides,
+  };
+}
+
+function readerAllowing(
+  grants: ReadonlyArray<{ scopeId: string; role: string }>,
+): RoleGrantsReader {
+  return {
+    hasActiveGrant: ({ scopeId, role }: GrantQuery) =>
+      Promise.resolve(grants.some((g) => g.scopeId === scopeId && g.role === role)),
+  };
+}
+
+describe("assertChancellorOf", () => {
+  it("allows an active chancellor grant", async () => {
+    await assertChancellorOf(
+      caller(),
+      "uni1",
+      readerAllowing([{ scopeId: "uni1", role: "chancellor" }]),
+    );
+  });
+
+  it("rejects when there is no grant", async () => {
+    await expect(
+      assertChancellorOf(caller(), "uni1", readerAllowing([])),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  it("allows super-admin without consulting grants", async () => {
+    const reader = { hasActiveGrant: mock(() => Promise.resolve(false)) };
+    await assertChancellorOf(caller({ superAdmin: true }), "uni1", reader);
+    expect(reader.hasActiveGrant).not.toHaveBeenCalled();
+  });
+});
+
+describe("assertCounselorOf", () => {
+  const scope = { universityId: "uni1", classId: "cls1" };
+
+  it("allows an active counselor grant on the class", async () => {
+    await assertCounselorOf(
+      caller(),
+      scope,
+      readerAllowing([{ scopeId: "cls1", role: "counselor" }]),
+    );
+  });
+
+  it("allows a chancellor of the owning university (chancellor supersedes)", async () => {
+    await assertCounselorOf(
+      caller(),
+      scope,
+      readerAllowing([{ scopeId: "uni1", role: "chancellor" }]),
+    );
+  });
+
+  it("rejects when neither grant exists", async () => {
+    await expect(
+      assertCounselorOf(caller(), scope, readerAllowing([])),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  it("allows super-admin", async () => {
+    await assertCounselorOf(
+      caller({ superAdmin: true }),
+      scope,
+      readerAllowing([]),
+    );
+  });
+});
+
+describe("assertOwnsScout", () => {
+  const readerFor = (owns: boolean): ScoutOwnershipReader => ({
+    exists: () => Promise.resolve(owns),
+  });
+
+  it("allows the owning parent", async () => {
+    await assertOwnsScout(caller(), "scout1", readerFor(true));
+  });
+
+  it("rejects a non-owner (no super-admin bypass)", async () => {
+    await expect(
+      assertOwnsScout(caller({ superAdmin: true }), "scout1", readerFor(false)),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+});
+
+describe("requireSuperAdmin", () => {
+  it("allows a super-admin", () => {
+    requireSuperAdmin(caller({ superAdmin: true }));
+  });
+
+  it("rejects a non-super-admin", () => {
+    expect(() => requireSuperAdmin(caller())).toThrow(ForbiddenError);
+  });
+});

--- a/functions/src/shared-api/services/authz/assertions.ts
+++ b/functions/src/shared-api/services/authz/assertions.ts
@@ -1,0 +1,84 @@
+import { ForbiddenError } from "../../errors/http-error.js";
+import type { Caller } from "../../types/caller.js";
+import {
+  roleGrantsReader,
+  type RoleGrantsReader,
+} from "./role-grants-reader.js";
+import {
+  scoutOwnershipReader,
+  type ScoutOwnershipReader,
+} from "./scout-ownership-reader.js";
+
+/**
+ * Contextual authorization primitives. Each resolves the ONE grant for the ONE
+ * scope in the request (no eager loading of all a caller's grants) and throws a
+ * 403 on miss. Super-admin bypasses role checks; scout ownership is strict
+ * (youth PII) and has no bypass.
+ */
+
+/** Require the caller to be an active chancellor of the university (or super-admin). */
+export async function assertChancellorOf(
+  caller: Caller,
+  universityId: string,
+  reader: RoleGrantsReader = roleGrantsReader,
+): Promise<void> {
+  if (caller.superAdmin) return;
+  if (
+    await reader.hasActiveGrant({
+      uid: caller.uid,
+      scopeId: universityId,
+      role: "chancellor",
+    })
+  ) {
+    return;
+  }
+  throw new ForbiddenError("You are not a chancellor of this university");
+}
+
+/**
+ * Require the caller to be an active counselor of the class — or a chancellor of
+ * the owning university (chancellors supersede), or super-admin.
+ */
+export async function assertCounselorOf(
+  caller: Caller,
+  scope: { universityId: string; classId: string },
+  reader: RoleGrantsReader = roleGrantsReader,
+): Promise<void> {
+  if (caller.superAdmin) return;
+  if (
+    await reader.hasActiveGrant({
+      uid: caller.uid,
+      scopeId: scope.classId,
+      role: "counselor",
+    })
+  ) {
+    return;
+  }
+  if (
+    await reader.hasActiveGrant({
+      uid: caller.uid,
+      scopeId: scope.universityId,
+      role: "chancellor",
+    })
+  ) {
+    return;
+  }
+  throw new ForbiddenError("You are not a counselor of this class");
+}
+
+/** Require the caller to own the scout (parent-of-scout). No super-admin bypass. */
+export async function assertOwnsScout(
+  caller: Caller,
+  scoutId: string,
+  reader: ScoutOwnershipReader = scoutOwnershipReader,
+): Promise<void> {
+  if (await reader.exists(caller.uid, scoutId)) return;
+  throw new ForbiddenError("You do not have access to this scout");
+}
+
+/** Require the super-admin custom claim. */
+export function requireSuperAdmin(caller: Caller): void {
+  if (!caller.superAdmin) {
+    throw new ForbiddenError("Super-admin privileges required");
+  }
+}

--- a/functions/src/shared-api/services/authz/index.ts
+++ b/functions/src/shared-api/services/authz/index.ts
@@ -1,0 +1,3 @@
+export * from "./assertions.js";
+export * from "./role-grants-reader.js";
+export * from "./scout-ownership-reader.js";

--- a/functions/src/shared-api/services/authz/role-grants-reader.ts
+++ b/functions/src/shared-api/services/authz/role-grants-reader.ts
@@ -1,0 +1,39 @@
+import { getFirestore } from "firebase-admin/firestore";
+import {
+  type GrantRole,
+  ROLE_GRANTS_COLLECTION,
+} from "../../../collections/role-grants.js";
+
+/** A specific (person, scope, role) grant lookup. */
+export interface GrantQuery {
+  uid: string;
+  scopeId: string;
+  role: GrantRole;
+}
+
+/**
+ * Reads roleGrants for authorization checks. Injected into the assertion
+ * primitives so they can be unit-tested without Firestore.
+ */
+export interface RoleGrantsReader {
+  hasActiveGrant(query: GrantQuery): Promise<boolean>;
+}
+
+/**
+ * Live reader. The all-equality query (uid, scopeId, role, status) is served by
+ * Firestore's automatic single-field indexes via a zig-zag merge — no composite
+ * index required.
+ */
+export const roleGrantsReader: RoleGrantsReader = {
+  async hasActiveGrant({ uid, scopeId, role }) {
+    const snapshot = await getFirestore()
+      .collection(ROLE_GRANTS_COLLECTION)
+      .where("uid", "==", uid)
+      .where("scopeId", "==", scopeId)
+      .where("role", "==", role)
+      .where("status", "==", "active")
+      .limit(1)
+      .get();
+    return !snapshot.empty;
+  },
+};

--- a/functions/src/shared-api/services/authz/scout-ownership-reader.ts
+++ b/functions/src/shared-api/services/authz/scout-ownership-reader.ts
@@ -1,0 +1,20 @@
+import { getFirestore } from "firebase-admin/firestore";
+import { scoutsPath } from "../../../collections/scouts.js";
+
+/**
+ * Checks whether a scout profile exists under a given parent. Injected into
+ * `assertOwnsScout` for unit testing without Firestore.
+ */
+export interface ScoutOwnershipReader {
+  exists(parentUid: string, scoutId: string): Promise<boolean>;
+}
+
+/** Live reader — a single doc get on the parent's scouts subcollection. */
+export const scoutOwnershipReader: ScoutOwnershipReader = {
+  async exists(parentUid, scoutId) {
+    const snapshot = await getFirestore()
+      .doc(`${scoutsPath(parentUid)}/${scoutId}`)
+      .get();
+    return snapshot.exists;
+  },
+};

--- a/functions/src/shared-api/types/caller.ts
+++ b/functions/src/shared-api/types/caller.ts
@@ -1,0 +1,11 @@
+/**
+ * The authenticated caller, derived from a verified Firebase ID token by the
+ * `requireAuth` resolver. Past that resolver, `emailVerified` is always true and
+ * `email` is lowercased (the identity key used for invite claiming).
+ */
+export interface Caller {
+  uid: string;
+  email: string;
+  emailVerified: boolean;
+  superAdmin: boolean;
+}

--- a/functions/src/users-api/app.test.ts
+++ b/functions/src/users-api/app.test.ts
@@ -1,0 +1,170 @@
+import type { DecodedIdToken } from "firebase-admin/auth";
+import { describe, expect, it } from "bun:test";
+import type { TokenVerifier } from "../shared-api/plugins/require-auth.js";
+import { handleRequest } from "../test-utils/handle-request.js";
+import { createApp } from "./app.js";
+import type { ScoutsService } from "./services/scouts/interface.js";
+import type { UsersService } from "./services/users/interface.js";
+
+const verified: TokenVerifier = () =>
+  Promise.resolve({
+    uid: "u1",
+    email: "u1@example.com",
+    email_verified: true,
+  } as DecodedIdToken);
+
+const unverified: TokenVerifier = () =>
+  Promise.resolve({
+    uid: "u1",
+    email: "u1@example.com",
+    email_verified: false,
+  } as DecodedIdToken);
+
+const usersService: UsersService = {
+  bootstrap: (caller) =>
+    Promise.resolve({
+      user: {
+        uid: caller.uid,
+        displayName: "",
+        email: caller.email,
+        phone: null,
+        acceptedTermsAt: null,
+        acceptedPrivacyAt: null,
+      },
+      needsConsent: true,
+    }),
+  getMe: (caller) =>
+    Promise.resolve({
+      uid: caller.uid,
+      displayName: "Pat",
+      email: caller.email,
+      phone: null,
+      acceptedTermsAt: null,
+      acceptedPrivacyAt: null,
+    }),
+  onboard: (caller, request) =>
+    Promise.resolve({
+      uid: caller.uid,
+      displayName: request.displayName,
+      email: caller.email,
+      phone: null,
+      acceptedTermsAt: "2026-07-03T00:00:00.000Z",
+      acceptedPrivacyAt: "2026-07-03T00:00:00.000Z",
+    }),
+};
+
+const scoutsService: ScoutsService = {
+  list: () => Promise.resolve({ scouts: [] }),
+  create: (_caller, request) =>
+    Promise.resolve({
+      scoutId: "s1",
+      firstName: request.firstName,
+      lastName: request.lastName,
+      unit: request.unit ?? null,
+      council: null,
+      district: null,
+      ageBand: null,
+      bsaId: null,
+      accommodations: null,
+    }),
+  update: (_caller, scoutId, request) =>
+    Promise.resolve({
+      scoutId,
+      firstName: request.firstName,
+      lastName: request.lastName,
+      unit: null,
+      council: null,
+      district: null,
+      ageBand: null,
+      bsaId: null,
+      accommodations: null,
+    }),
+  remove: () => Promise.resolve(),
+};
+
+function authed(path: string, method: string, body?: unknown): Request {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: { authorization: "Bearer x", "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+describe("users-api auth gate", () => {
+  it("rejects a request with no Authorization header (401)", async () => {
+    const app = createApp({ usersService, scoutsService });
+    const response = await handleRequest(
+      app,
+      new Request("http://localhost/api/users/me", { method: "POST" }),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects an unverified email with 403 EMAIL_NOT_VERIFIED", async () => {
+    const app = createApp({ usersService, scoutsService, verifyToken: unverified });
+    const response = await handleRequest(app, authed("/api/users/me", "POST"));
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { code?: string };
+    expect(body.code).toBe("EMAIL_NOT_VERIFIED");
+  });
+});
+
+describe("users-api routes", () => {
+  const app = () =>
+    createApp({ usersService, scoutsService, verifyToken: verified });
+
+  it("POST /api/users/me bootstraps and reports needsConsent", async () => {
+    const response = await handleRequest(app(), authed("/api/users/me", "POST"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      needsConsent: boolean;
+      user: { uid: string };
+    };
+    expect(body.needsConsent).toBe(true);
+    expect(body.user.uid).toBe("u1");
+  });
+
+  it("PATCH /api/users/me records onboarding when terms are accepted", async () => {
+    const response = await handleRequest(
+      app(),
+      authed("/api/users/me", "PATCH", {
+        displayName: "Pat Parent",
+        acceptedTerms: true,
+      }),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { displayName: string };
+    expect(body.displayName).toBe("Pat Parent");
+  });
+
+  it("PATCH /api/users/me rejects a body without accepted terms (400)", async () => {
+    const response = await handleRequest(
+      app(),
+      authed("/api/users/me", "PATCH", { displayName: "Pat" }),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("POST /api/users/me/scouts creates a scout", async () => {
+    const response = await handleRequest(
+      app(),
+      authed("/api/users/me/scouts", "POST", {
+        firstName: "Amy",
+        lastName: "Scout",
+      }),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { scoutId: string };
+    expect(body.scoutId).toBe("s1");
+  });
+
+  it("GET /api/users/me/scouts lists scouts", async () => {
+    const response = await handleRequest(
+      app(),
+      authed("/api/users/me/scouts", "GET"),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { scouts: unknown[] };
+    expect(body.scouts).toEqual([]);
+  });
+});

--- a/functions/src/users-api/app.ts
+++ b/functions/src/users-api/app.ts
@@ -1,0 +1,63 @@
+import { node } from "@elysiajs/node";
+import { Elysia } from "elysia";
+import { mapError } from "../shared-api/errors/on-error.js";
+import { requireAuth } from "../shared-api/plugins/require-auth.js";
+import { verifyAuthToken } from "../shared-api/services/auth/verify-token.js";
+import {
+  ScoutListResponseSchema,
+  ScoutRequestSchema,
+  ScoutResponseSchema,
+} from "./schemas/scout-schemas.js";
+import {
+  BootstrapResponseSchema,
+  OnboardingRequestSchema,
+  UserResponseSchema,
+} from "./schemas/user-schemas.js";
+import { scoutsService as defaultScouts } from "./services/scouts/index.js";
+import { usersService as defaultUsers } from "./services/users/index.js";
+import type { PartialUsersApiServices } from "./types/services.js";
+
+/**
+ * Create the users-api Elysia app with injectable dependencies.
+ *
+ * Firebase hosting routes /api/users/** → usersApi function. Every route runs
+ * behind `requireAuth` (verified identity required); authorization for scoped
+ * actions uses the shared-api/authz primitives inside the relevant services.
+ */
+export function createApp(services?: PartialUsersApiServices) {
+  const users = services?.usersService ?? defaultUsers;
+  const scouts = services?.scoutsService ?? defaultScouts;
+  const verifyToken = services?.verifyToken ?? verifyAuthToken;
+
+  return new Elysia({ adapter: node(), prefix: "/api" })
+    .onError(mapError)
+    .resolve(requireAuth(verifyToken))
+    .post("/users/me", ({ caller }) => users.bootstrap(caller), {
+      response: BootstrapResponseSchema,
+    })
+    .get("/users/me", ({ caller }) => users.getMe(caller), {
+      response: UserResponseSchema,
+    })
+    .patch("/users/me", ({ caller, body }) => users.onboard(caller, body), {
+      body: OnboardingRequestSchema,
+      response: UserResponseSchema,
+    })
+    .get("/users/me/scouts", ({ caller }) => scouts.list(caller), {
+      response: ScoutListResponseSchema,
+    })
+    .post("/users/me/scouts", ({ caller, body }) => scouts.create(caller, body), {
+      body: ScoutRequestSchema,
+      response: ScoutResponseSchema,
+    })
+    .patch(
+      "/users/me/scouts/:scoutId",
+      ({ caller, params, body }) => scouts.update(caller, params.scoutId, body),
+      { body: ScoutRequestSchema, response: ScoutResponseSchema },
+    )
+    .delete("/users/me/scouts/:scoutId", async ({ caller, params, set }) => {
+      await scouts.remove(caller, params.scoutId);
+      set.status = 204;
+    });
+}
+
+export const app = createApp();

--- a/functions/src/users-api/handler.ts
+++ b/functions/src/users-api/handler.ts
@@ -1,0 +1,20 @@
+import { logger as firebaseLogger } from "firebase-functions/v2";
+import type { Request } from "firebase-functions/v2/https";
+import type { FirebaseResponse } from "../shared-api/types/firebase-response.js";
+import type { Logger } from "../shared-api/types/logger.js";
+import { handleElysiaRequest } from "../shared-api/utils/handle-elysia-request.js";
+
+export async function handleUsersApi(
+  request: Request,
+  response: FirebaseResponse,
+  logger: Logger = firebaseLogger,
+): Promise<void> {
+  const { app } = await import("./app.js");
+  return handleElysiaRequest({
+    app,
+    request,
+    response,
+    logger,
+    apiName: "users-api",
+  });
+}

--- a/functions/src/users-api/schemas/scout-schemas.ts
+++ b/functions/src/users-api/schemas/scout-schemas.ts
@@ -1,0 +1,43 @@
+import { t, type Static } from "elysia";
+
+/** Coarse age band — matches collections/scouts AgeBand (never store DOB). */
+export const AgeBandSchema = t.Union([
+  t.Literal("10-11"),
+  t.Literal("12-13"),
+  t.Literal("14-15"),
+  t.Literal("16-17"),
+]);
+
+const OptionalNullableString = t.Optional(t.Union([t.String(), t.Null()]));
+
+/** Create/update payload for a dependent scout profile. */
+export const ScoutRequestSchema = t.Object({
+  firstName: t.String({ minLength: 1 }),
+  lastName: t.String({ minLength: 1 }),
+  unit: OptionalNullableString,
+  council: OptionalNullableString,
+  district: OptionalNullableString,
+  ageBand: t.Optional(t.Union([AgeBandSchema, t.Null()])),
+  bsaId: OptionalNullableString,
+  accommodations: OptionalNullableString,
+});
+export type ScoutRequest = Static<typeof ScoutRequestSchema>;
+
+/** Scout profile serialized for the client. */
+export const ScoutResponseSchema = t.Object({
+  scoutId: t.String(),
+  firstName: t.String(),
+  lastName: t.String(),
+  unit: t.Union([t.String(), t.Null()]),
+  council: t.Union([t.String(), t.Null()]),
+  district: t.Union([t.String(), t.Null()]),
+  ageBand: t.Union([AgeBandSchema, t.Null()]),
+  bsaId: t.Union([t.String(), t.Null()]),
+  accommodations: t.Union([t.String(), t.Null()]),
+});
+export type ScoutResponse = Static<typeof ScoutResponseSchema>;
+
+export const ScoutListResponseSchema = t.Object({
+  scouts: t.Array(ScoutResponseSchema),
+});
+export type ScoutListResponse = Static<typeof ScoutListResponseSchema>;

--- a/functions/src/users-api/schemas/user-schemas.ts
+++ b/functions/src/users-api/schemas/user-schemas.ts
@@ -1,0 +1,26 @@
+import { t, type Static } from "elysia";
+
+/** Adult account, serialized for the client (Timestamps → ISO strings). */
+export const UserResponseSchema = t.Object({
+  uid: t.String(),
+  displayName: t.String(),
+  email: t.String(),
+  phone: t.Union([t.String(), t.Null()]),
+  acceptedTermsAt: t.Union([t.String(), t.Null()]),
+  acceptedPrivacyAt: t.Union([t.String(), t.Null()]),
+});
+export type UserResponse = Static<typeof UserResponseSchema>;
+
+/** Bootstrap result: the user doc plus whether onboarding/consent is still required. */
+export const BootstrapResponseSchema = t.Object({
+  user: UserResponseSchema,
+  needsConsent: t.Boolean(),
+});
+export type BootstrapResponse = Static<typeof BootstrapResponseSchema>;
+
+/** Onboarding submission: name + the combined Terms/Privacy acceptance. */
+export const OnboardingRequestSchema = t.Object({
+  displayName: t.String({ minLength: 1 }),
+  acceptedTerms: t.Literal(true),
+});
+export type OnboardingRequest = Static<typeof OnboardingRequestSchema>;

--- a/functions/src/users-api/services/scouts/index.ts
+++ b/functions/src/users-api/services/scouts/index.ts
@@ -1,0 +1,94 @@
+import { FieldValue, getFirestore } from "firebase-admin/firestore";
+import { type ScoutDocument, scoutsPath } from "../../../collections/scouts.js";
+import { NotFoundError } from "../../../shared-api/errors/http-error.js";
+import type { Caller } from "../../../shared-api/types/caller.js";
+import type {
+  ScoutListResponse,
+  ScoutRequest,
+  ScoutResponse,
+} from "../../schemas/scout-schemas.js";
+import type { ScoutsService } from "./interface.js";
+
+/** Map the optional-field request onto the fully-nulled stored shape. */
+function scoutFields(request: ScoutRequest) {
+  return {
+    firstName: request.firstName,
+    lastName: request.lastName,
+    unit: request.unit ?? null,
+    council: request.council ?? null,
+    district: request.district ?? null,
+    ageBand: request.ageBand ?? null,
+    bsaId: request.bsaId ?? null,
+    accommodations: request.accommodations ?? null,
+  };
+}
+
+function toScoutResponse(scoutId: string, doc: ScoutDocument): ScoutResponse {
+  return {
+    scoutId,
+    firstName: doc.firstName,
+    lastName: doc.lastName,
+    unit: doc.unit,
+    council: doc.council,
+    district: doc.district,
+    ageBand: doc.ageBand,
+    bsaId: doc.bsaId,
+    accommodations: doc.accommodations,
+  };
+}
+
+export class ScoutsServiceImpl implements ScoutsService {
+  async list(caller: Caller): Promise<ScoutListResponse> {
+    const snapshot = await getFirestore()
+      .collection(scoutsPath(caller.uid))
+      .orderBy("createdAt")
+      .get();
+    return {
+      scouts: snapshot.docs.map((doc) =>
+        toScoutResponse(doc.id, doc.data() as ScoutDocument),
+      ),
+    };
+  }
+
+  async create(caller: Caller, request: ScoutRequest): Promise<ScoutResponse> {
+    const reference = getFirestore().collection(scoutsPath(caller.uid)).doc();
+    await reference.set({
+      ...scoutFields(request),
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+    return toScoutResponse(
+      reference.id,
+      (await reference.get()).data() as ScoutDocument,
+    );
+  }
+
+  async update(
+    caller: Caller,
+    scoutId: string,
+    request: ScoutRequest,
+  ): Promise<ScoutResponse> {
+    const reference = getFirestore().doc(`${scoutsPath(caller.uid)}/${scoutId}`);
+    if (!(await reference.get()).exists) {
+      throw new NotFoundError("Scout not found");
+    }
+    await reference.set(
+      { ...scoutFields(request), updatedAt: FieldValue.serverTimestamp() },
+      { merge: true },
+    );
+    return toScoutResponse(
+      scoutId,
+      (await reference.get()).data() as ScoutDocument,
+    );
+  }
+
+  async remove(caller: Caller, scoutId: string): Promise<void> {
+    const reference = getFirestore().doc(`${scoutsPath(caller.uid)}/${scoutId}`);
+    if (!(await reference.get()).exists) {
+      throw new NotFoundError("Scout not found");
+    }
+    await reference.delete();
+  }
+}
+
+export const scoutsService = new ScoutsServiceImpl();

--- a/functions/src/users-api/services/scouts/interface.ts
+++ b/functions/src/users-api/services/scouts/interface.ts
@@ -1,0 +1,18 @@
+import type { Caller } from "../../../shared-api/types/caller.js";
+import type {
+  ScoutListResponse,
+  ScoutRequest,
+  ScoutResponse,
+} from "../../schemas/scout-schemas.js";
+
+export interface ScoutsService {
+  list(caller: Caller): Promise<ScoutListResponse>;
+  create(caller: Caller, request: ScoutRequest): Promise<ScoutResponse>;
+  update(
+    caller: Caller,
+    scoutId: string,
+    request: ScoutRequest,
+  ): Promise<ScoutResponse>;
+  /** Hard-delete; 404 if missing. Cascade vs active registrations is #84. */
+  remove(caller: Caller, scoutId: string): Promise<void>;
+}

--- a/functions/src/users-api/services/users/index.ts
+++ b/functions/src/users-api/services/users/index.ts
@@ -1,0 +1,126 @@
+import { FieldValue, getFirestore, Timestamp } from "firebase-admin/firestore";
+import { ROLE_GRANTS_COLLECTION } from "../../../collections/role-grants.js";
+import { USERS_COLLECTION, type UserDocument } from "../../../collections/users.js";
+import { NotFoundError } from "../../../shared-api/errors/http-error.js";
+import type { Caller } from "../../../shared-api/types/caller.js";
+import type {
+  BootstrapResponse,
+  OnboardingRequest,
+  UserResponse,
+} from "../../schemas/user-schemas.js";
+import type { UsersService } from "./interface.js";
+
+function toIso(value: Timestamp | null): string | null {
+  return value instanceof Timestamp ? value.toDate().toISOString() : null;
+}
+
+function toUserResponse(uid: string, doc: UserDocument): UserResponse {
+  return {
+    uid,
+    displayName: doc.displayName,
+    email: doc.email,
+    phone: doc.phone,
+    acceptedTermsAt: toIso(doc.acceptedTermsAt),
+    acceptedPrivacyAt: toIso(doc.acceptedPrivacyAt),
+  };
+}
+
+export class UsersServiceImpl implements UsersService {
+  async bootstrap(caller: Caller): Promise<BootstrapResponse> {
+    const database = getFirestore();
+    const reference = database.collection(USERS_COLLECTION).doc(caller.uid);
+    const existing = await reference.get();
+
+    if (existing.exists) {
+      // Keep the mirrored email in sync with Auth (authoritative).
+      await reference.set(
+        { email: caller.email, updatedAt: FieldValue.serverTimestamp() },
+        { merge: true },
+      );
+    } else {
+      // displayName is set during onboarding; start blank rather than guessing.
+      await reference.set({
+        displayName: "",
+        email: caller.email,
+        phone: null,
+        counselorProfile: null,
+        acceptedTermsAt: null,
+        acceptedPrivacyAt: null,
+        createdAt: FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+    }
+
+    await this.claimPendingInvites(caller);
+
+    const fresh = (await reference.get()).data() as UserDocument;
+    return {
+      user: toUserResponse(caller.uid, fresh),
+      needsConsent:
+        fresh.acceptedTermsAt === null || fresh.acceptedPrivacyAt === null,
+    };
+  }
+
+  async getMe(caller: Caller): Promise<UserResponse> {
+    const snapshot = await getFirestore()
+      .collection(USERS_COLLECTION)
+      .doc(caller.uid)
+      .get();
+    if (!snapshot.exists) {
+      throw new NotFoundError("User not found");
+    }
+    return toUserResponse(caller.uid, snapshot.data() as UserDocument);
+  }
+
+  async onboard(
+    caller: Caller,
+    request: OnboardingRequest,
+  ): Promise<UserResponse> {
+    const reference = getFirestore()
+      .collection(USERS_COLLECTION)
+      .doc(caller.uid);
+    if (!(await reference.get()).exists) {
+      throw new NotFoundError("User not found; bootstrap the session first");
+    }
+    await reference.set(
+      {
+        displayName: request.displayName,
+        acceptedTermsAt: FieldValue.serverTimestamp(),
+        acceptedPrivacyAt: FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+      },
+      { merge: true },
+    );
+    return toUserResponse(
+      caller.uid,
+      (await reference.get()).data() as UserDocument,
+    );
+  }
+
+  /**
+   * Bind any email-keyed counselor/chancellor invites to this uid and activate
+   * them. Uses the (invitedEmail, status) index; caller.email is lowercased to
+   * match the stored invitedEmail.
+   */
+  private async claimPendingInvites(caller: Caller): Promise<void> {
+    const database = getFirestore();
+    const pending = await database
+      .collection(ROLE_GRANTS_COLLECTION)
+      .where("invitedEmail", "==", caller.email)
+      .where("status", "==", "invited")
+      .get();
+    if (pending.empty) return;
+
+    const batch = database.batch();
+    for (const grant of pending.docs) {
+      batch.update(grant.ref, {
+        uid: caller.uid,
+        status: "active",
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+    }
+    await batch.commit();
+  }
+}
+
+export const usersService = new UsersServiceImpl();

--- a/functions/src/users-api/services/users/interface.ts
+++ b/functions/src/users-api/services/users/interface.ts
@@ -1,0 +1,19 @@
+import type { Caller } from "../../../shared-api/types/caller.js";
+import type {
+  BootstrapResponse,
+  OnboardingRequest,
+  UserResponse,
+} from "../../schemas/user-schemas.js";
+
+export interface UsersService {
+  /**
+   * Idempotently create-or-refresh the caller's user doc, claim any pending
+   * counselor invites addressed to their email, and report whether onboarding
+   * consent is still required.
+   */
+  bootstrap(caller: Caller): Promise<BootstrapResponse>;
+  /** Read the caller's user doc (404 if it does not exist yet). */
+  getMe(caller: Caller): Promise<UserResponse>;
+  /** Record displayName + Terms/Privacy consent timestamps. */
+  onboard(caller: Caller, request: OnboardingRequest): Promise<UserResponse>;
+}

--- a/functions/src/users-api/types/services.ts
+++ b/functions/src/users-api/types/services.ts
@@ -1,0 +1,16 @@
+import type { TokenVerifier } from "../../shared-api/plugins/require-auth.js";
+import type { ScoutsService } from "../services/scouts/interface.js";
+import type { UsersService } from "../services/users/interface.js";
+
+/**
+ * Injectable dependencies for the users-api app. Tests override any subset;
+ * production uses the live defaults wired in app.ts.
+ */
+export interface UsersApiServices {
+  usersService: UsersService;
+  scoutsService: ScoutsService;
+  /** Token verifier used by the requireAuth resolver (fakeable in tests). */
+  verifyToken: TokenVerifier;
+}
+
+export type PartialUsersApiServices = Partial<UsersApiServices>;

--- a/functions/vitest.config.ts
+++ b/functions/vitest.config.ts
@@ -1,8 +1,0 @@
-import { defineConfig } from "vitest/config";
-
-export default defineConfig({
-  test: {
-    environment: "node",
-    include: ["src/**/*.test.ts"],
-  },
-});


### PR DESCRIPTION
Implements **#81** (MBU Platform Phase 1). Design resolved in the #81 grilling; ports patterns from the doula-cooperative app.

## Backend (`functions/`)
- **shared-api auth foundation** — `HttpError` hierarchy, `verify-token` (Bearer + `verifyIdToken`), `require-auth` Elysia resolver enforcing `email_verified` (distinct `EMAIL_NOT_VERIFIED` 403), `onError` mapper, `Caller`.
- **authz primitives** (`shared-api/services/authz/`) — `assertChancellorOf` / `assertCounselorOf` (chancellor supersedes) / `assertOwnsScout` / `requireSuperAdmin`, roleGrants-backed, one lookup per request-scope.
- **users-api module** — `POST/GET/PATCH /api/users/me` (idempotent bootstrap upsert + email-keyed counselor-invite claiming + onboarding consent) and scout CRUD; TypeBox schemas; route tests with injected fakes.
- **Wiring** — `usersApi` function, `/api/users{,/**}` hosting rewrite, `set-initial-super-admin.ts` bootstrap script.
- Enforcement stays **Elysia-only**; `firestore.rules` remains deny-all (unchanged).

## Frontend (`app/`)
- **`Auth`** service (signal via `onIdTokenChanged`, bootstrap `session` resource gated on verified email, `getIdToken(true)` refresh, `superAdmin` claim), **`authInterceptor`** (`/api` allowlist, 401 → sign-out), **guard chain** auth → verified → onboarded, **sign-in / verify-email / onboarding** components, api-types, dev proxy.

## Testing
- Migrated `functions/` tests **Vitest → `bun test`**; test files now linted (`tsconfig.test.json`); removed stale `vitest.config.ts`.
- **Verified:** functions build/typecheck/lint + 36 `bun test`; app build/lint + 21 vitest; 3 Playwright smoke e2e (Auth-emulator-only, `/api` stubbed per doula pattern); a one-off Auth-emulator integration proved verify-token/require-auth/superAdmin against **real** Firebase tokens.

## Follow-ups
- #97 — replace emulator rules-unit-tests with a static deny-all invariant check.
- #98 — full-emulator e2e exercising real Firestore data flows (deferred; smoke e2e covers wiring).

Closes #81.