### PR TITLE
Add link-only unlisted event access (#83)

### DIFF
--- a/app/src/app/api-types/universities-api.types.ts
+++ b/app/src/app/api-types/universities-api.types.ts
@@ -144,6 +144,38 @@ export interface UniversityDetailResponse {
   classes: ClassResponse[];
 }
 
+export interface PublicClassCounselor {
+  displayName: string;
+}
+
+export interface PublicClass {
+  classId: string;
+  badgeSlug: string;
+  badgeTitle: string;
+  eagleRequired: boolean;
+  periodIds: string[];
+  room: string | null;
+  notes: string | null;
+  capacity: number;
+  enrolledCount: number;
+  seatsRemaining: number;
+  waitlistCount: number;
+  counselors: PublicClassCounselor[];
+}
+
+export interface PublicUniversity {
+  id: string;
+  title: string;
+  timezone: string;
+  startDate: string;
+  endDate: string | null;
+  registrationOpensAt: string | null;
+  registrationClosesAt: string;
+  location: UniversityLocation;
+  periods: Period[];
+  classes: PublicClass[];
+}
+
 export interface ApiErrorBody {
   error?: string;
   code?: string;

--- a/app/src/app/app.routes.ts
+++ b/app/src/app/app.routes.ts
@@ -8,6 +8,11 @@ import {
 
 export const routes: Routes = [
   {
+    path: 'e/:id',
+    loadComponent: () =>
+      import('./public-event/public-event').then((m) => m.PublicEvent),
+  },
+  {
     path: 'sign-in',
     canActivate: [requireUnauth],
     loadComponent: () => import('./sign-in/sign-in').then((m) => m.SignIn),

--- a/app/src/app/guards/auth-guards.spec.ts
+++ b/app/src/app/guards/auth-guards.spec.ts
@@ -64,6 +64,7 @@ const routes: Routes = [
   { path: 'protected', component: MockProtected, canActivate: [requireAuth] },
   { path: 'verified-only', component: MockProtected, canActivate: [requireVerified] },
   { path: 'guest-only', component: MockSignIn, canActivate: [requireUnauth] },
+  { path: 'return-target', component: MockProtected },
   { path: 'onboarded-only', component: MockProtected, canActivate: [requireOnboarded] },
 ];
 
@@ -109,6 +110,14 @@ describe('auth route guards', () => {
       });
       await navigate('/guest-only');
       expect(screen.getByText('Home')).toBeVisible();
+    });
+
+    it('redirects an authenticated user to returnTo when provided', async () => {
+      const { navigate } = await setup({
+        currentUser: { uid: 'u1', emailVerified: true },
+      });
+      await navigate('/guest-only?returnTo=%2Freturn-target');
+      expect(screen.getByText('Protected')).toBeVisible();
     });
 
     it('allows an unauthenticated user to reach the guest-only page', async () => {

--- a/app/src/app/guards/auth-guards.ts
+++ b/app/src/app/guards/auth-guards.ts
@@ -1,6 +1,7 @@
 import { inject } from '@angular/core';
 import { Router, type CanActivateFn } from '@angular/router';
 import { auth } from '../lib/firebase';
+import { safeReturnTo } from '../lib/return-to';
 import { Auth } from '../services/auth';
 
 /**
@@ -35,8 +36,9 @@ export const requireOnboarded: CanActivateFn = async () => {
 };
 
 /** Inverse of requireAuth: sends already signed-in users to the app home. */
-export const requireUnauth: CanActivateFn = async () => {
+export const requireUnauth: CanActivateFn = async (route) => {
   const router = inject(Router);
   await auth.authStateReady();
-  return auth.currentUser ? router.parseUrl('/') : true;
+  if (!auth.currentUser) return true;
+  return router.parseUrl(safeReturnTo(route.queryParamMap));
 };

--- a/app/src/app/lib/return-to.ts
+++ b/app/src/app/lib/return-to.ts
@@ -1,0 +1,16 @@
+import type { ParamMap } from '@angular/router';
+
+/**
+ * Resolve a `returnTo` query param to a safe same-origin path.
+ *
+ * Only accepts absolute in-app paths (`/foo`); rejects protocol-relative
+ * (`//evil.com`) and anything else to prevent open redirects. Falls back to
+ * the app home when absent or unsafe.
+ */
+export function safeReturnTo(params: ParamMap): string {
+  const value = params.get('returnTo');
+  if (value?.startsWith('/') && !value.startsWith('//')) {
+    return value;
+  }
+  return '/';
+}

--- a/app/src/app/public-event/public-event.css
+++ b/app/src/app/public-event/public-event.css
@@ -1,0 +1,53 @@
+@layer components {
+  .public-event {
+    container-type: inline-size;
+    margin-inline: auto;
+    max-width: 40rem;
+    padding: clamp(1.5rem, 4cqi, 3rem);
+  }
+
+  .public-event h1 {
+    font-size: clamp(1.5rem, 5cqi, 2rem);
+    line-height: 1.2;
+    margin: 0 0 0.5rem;
+  }
+
+  .public-event__header p {
+    color: var(--color-muted);
+    margin: 0.25rem 0;
+  }
+
+  .public-event__periods,
+  .public-event__classes {
+    margin-block: 2rem;
+  }
+
+  .public-event__class-list {
+    display: grid;
+    gap: 1rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .public-event__class-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 0.75rem;
+    padding: 1rem;
+  }
+
+  .public-event__class-card h3 {
+    margin: 0 0 0.5rem;
+  }
+
+  .public-event__eagle {
+    color: var(--color-muted);
+    font-size: 0.875rem;
+    margin: 0 0 0.5rem;
+  }
+
+  .public-event__cta {
+    margin-top: 2rem;
+  }
+}

--- a/app/src/app/public-event/public-event.html
+++ b/app/src/app/public-event/public-event.html
@@ -1,0 +1,77 @@
+<main class="public-event">
+  @if (event.isLoading()) {
+    <p>Loading event…</p>
+  } @else if (notFound()) {
+    <h1>Event not found</h1>
+    <p>This event is not available or has not been published yet.</p>
+  } @else if (event.error()) {
+    <h1>Something went wrong</h1>
+    <p>We couldn't load this event. Please refresh to try again.</p>
+  } @else if (event.value(); as ev) {
+    <header class="public-event__header">
+      <h1>{{ ev.title }}</h1>
+      <p>{{ formatLocation(ev) }}</p>
+      <p>
+        {{ ev.startDate | date: 'mediumDate' : ev.timezone }}
+        @if (ev.endDate) {
+          – {{ ev.endDate | date: 'mediumDate' : ev.timezone }}
+        }
+      </p>
+    </header>
+
+    @if (ev.periods.length > 0) {
+      <section class="public-event__periods">
+        <h2>Periods</h2>
+        <ul>
+          @for (period of ev.periods; track period.periodId) {
+            <li>
+              <strong>{{ period.label }}</strong>
+              · {{ period.startsAt | date: 'shortTime' : ev.timezone }}
+              – {{ period.endsAt | date: 'shortTime' : ev.timezone }}
+            </li>
+          }
+        </ul>
+      </section>
+    }
+
+    <section class="public-event__classes">
+      <h2>Classes</h2>
+      @if (ev.classes.length === 0) {
+        <p>No classes listed yet.</p>
+      } @else {
+        <ul class="public-event__class-list">
+          @for (cls of ev.classes; track cls.classId) {
+            <li class="public-event__class-card">
+              <h3>{{ cls.badgeTitle }}</h3>
+              @if (cls.eagleRequired) {
+                <p class="public-event__eagle">Eagle-required</p>
+              }
+              <p>
+                {{ cls.enrolledCount }} of {{ cls.capacity }} seats filled ·
+                {{ cls.seatsRemaining }} seats left
+              </p>
+              @if (cls.waitlistCount > 0) {
+                <p>{{ cls.waitlistCount }} on waitlist</p>
+              }
+              @if (cls.counselors.length > 0) {
+                <p>Counselor: {{ counselorNames(cls.counselors) }}</p>
+              }
+              @if (cls.room) {
+                <p>Room: {{ cls.room }}</p>
+              }
+              @if (cls.notes) {
+                <p>{{ cls.notes }}</p>
+              }
+            </li>
+          }
+        </ul>
+      }
+    </section>
+
+    <p class="public-event__cta">
+      <a routerLink="/sign-in" [queryParams]="{ returnTo: signInReturnTo() }">
+        Sign in to register
+      </a>
+    </p>
+  }
+</main>

--- a/app/src/app/public-event/public-event.spec.ts
+++ b/app/src/app/public-event/public-event.spec.ts
@@ -1,0 +1,108 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router, RouterOutlet } from '@angular/router';
+import { render, screen } from '@testing-library/angular/zoneless';
+import { describe, expect, it } from 'vitest';
+import type { PublicUniversity } from '../api-types/universities-api.types';
+import { PublicEvent } from './public-event';
+
+@Component({
+  template: '<router-outlet />',
+  imports: [RouterOutlet],
+})
+class TestApp {}
+
+const sampleEvent: PublicUniversity = {
+  id: 'uni1',
+  title: 'Spring MBU',
+  timezone: 'America/New_York',
+  startDate: '2026-06-01T12:00:00.000Z',
+  endDate: null,
+  registrationOpensAt: null,
+  registrationClosesAt: '2026-05-25T23:59:59.000Z',
+  location: {
+    name: 'Scout Hall',
+    address: '1 Main St',
+    city: 'Anytown',
+    state: 'NY',
+    zip: '12345',
+  },
+  periods: [],
+  classes: [
+    {
+      classId: 'cls1',
+      badgeSlug: 'camping',
+      badgeTitle: 'Camping',
+      eagleRequired: true,
+      periodIds: ['p1'],
+      room: 'Room A',
+      notes: null,
+      capacity: 20,
+      enrolledCount: 8,
+      seatsRemaining: 12,
+      waitlistCount: 0,
+      counselors: [{ displayName: 'Alex Counselor' }],
+    },
+  ],
+};
+
+const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('PublicEvent', () => {
+  async function renderAt(path: string): Promise<HttpTestingController> {
+    await render(TestApp, {
+      providers: [
+        provideRouter([{ path: 'e/:id', component: PublicEvent }]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+    await TestBed.inject(Router).navigateByUrl(path);
+    await flushMicrotasks();
+    return TestBed.inject(HttpTestingController);
+  }
+
+  it('renders seat counts and the register CTA for a published event', async () => {
+    const httpMock = await renderAt('/e/uni1');
+
+    httpMock
+      .expectOne('/api/universities/uni1/public')
+      .flush(sampleEvent);
+
+    expect(await screen.findByText('Spring MBU')).toBeVisible();
+    expect(await screen.findByText(/8 of 20 seats filled/)).toBeVisible();
+    expect(await screen.findByText(/12 seats left/)).toBeVisible();
+
+    const cta = await screen.findByText('Sign in to register');
+    expect(cta).toBeVisible();
+    expect(cta.getAttribute('href')).toContain('returnTo=%2Fe%2Funi1');
+  });
+
+  it('shows a not-found message for a 404 (missing or unpublished)', async () => {
+    const httpMock = await renderAt('/e/missing');
+
+    httpMock
+      .expectOne('/api/universities/missing/public')
+      .flush('not found', { status: 404, statusText: 'Not Found' });
+
+    expect(await screen.findByText('Event not found')).toBeVisible();
+    expect(
+      await screen.findByText(/not available or has not been published yet/),
+    ).toBeVisible();
+  });
+
+  it('shows a generic error for a non-404 failure instead of a blank page', async () => {
+    const httpMock = await renderAt('/e/uni1');
+
+    httpMock
+      .expectOne('/api/universities/uni1/public')
+      .flush('boom', { status: 500, statusText: 'Server Error' });
+
+    expect(await screen.findByText('Something went wrong')).toBeVisible();
+  });
+});

--- a/app/src/app/public-event/public-event.ts
+++ b/app/src/app/public-event/public-event.ts
@@ -1,0 +1,47 @@
+import { DatePipe } from '@angular/common';
+import { HttpErrorResponse, httpResource } from '@angular/common/http';
+import { Component, computed, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import type { PublicUniversity } from '../api-types/universities-api.types';
+
+@Component({
+  selector: 'app-public-event',
+  imports: [DatePipe, RouterLink],
+  templateUrl: './public-event.html',
+  styleUrl: './public-event.css',
+})
+export class PublicEvent {
+  private readonly route = inject(ActivatedRoute);
+  private readonly params = toSignal(this.route.paramMap);
+
+  protected readonly eventId = computed(() => this.params()?.get('id') ?? '');
+
+  // Keyed on the route id: navigating between events refetches and cancels the
+  // superseded request, so a slow earlier response can't overwrite a later one.
+  protected readonly event = httpResource<PublicUniversity>(() => {
+    const id = this.eventId();
+    return id ? `/api/universities/${id}/public` : undefined;
+  });
+
+  /** A 404 means missing or unpublished; any other error is a generic failure. */
+  protected readonly notFound = computed(() => {
+    const error = this.event.error();
+    return error instanceof HttpErrorResponse && error.status === 404;
+  });
+
+  protected signInReturnTo(): string {
+    return `/e/${this.eventId()}`;
+  }
+
+  protected counselorNames(
+    counselors: PublicUniversity['classes'][number]['counselors'],
+  ): string {
+    return counselors.map((c) => c.displayName).join(', ');
+  }
+
+  protected formatLocation(event: PublicUniversity): string {
+    const { location } = event;
+    return `${location.name}, ${location.city}, ${location.state}`;
+  }
+}

--- a/app/src/app/sign-in/sign-in.ts
+++ b/app/src/app/sign-in/sign-in.ts
@@ -5,7 +5,8 @@ import {
   Validators,
   type FormGroup,
 } from '@angular/forms';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
+import { safeReturnTo } from '../lib/return-to';
 import { Auth } from '../services/auth';
 
 @Component({
@@ -18,6 +19,7 @@ import { Auth } from '../services/auth';
 export class SignIn {
   private readonly auth = inject(Auth);
   private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
   private readonly fb = inject(FormBuilder);
 
   protected readonly mode = signal<'sign-in' | 'sign-up'>('sign-in');
@@ -51,7 +53,7 @@ export class SignIn {
       await (this.mode() === 'sign-in'
         ? this.auth.signInWithEmailPassword(email, password)
         : this.auth.signUpWithEmailPassword(email, password));
-      await this.router.navigate(['/']);
+      await this.router.navigateByUrl(this.returnTo());
     } catch (error) {
       if (error instanceof Error) this.errorMessage.set(error.message);
     } finally {
@@ -64,11 +66,15 @@ export class SignIn {
     this.errorMessage.set('');
     try {
       await this.auth.signInWithGoogle();
-      await this.router.navigate(['/']);
+      await this.router.navigateByUrl(this.returnTo());
     } catch (error) {
       if (error instanceof Error) this.errorMessage.set(error.message);
     } finally {
       this.isLoading.set(false);
     }
+  }
+
+  private returnTo(): string {
+    return safeReturnTo(this.route.snapshot.queryParamMap);
   }
 }

--- a/functions/src/universities-api/app.test.ts
+++ b/functions/src/universities-api/app.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import type { DecodedIdToken } from "firebase-admin/auth";
 import {
   ForbiddenError,
+  NotFoundError,
   ValidationError,
 } from "../shared-api/errors/http-error.js";
 import type { TokenVerifier } from "../shared-api/plugins/require-auth.js";
@@ -46,7 +47,51 @@ const sampleUniversity = {
   updatedAt: "2026-07-01T00:00:00.000Z",
 };
 
+const samplePublicUniversity = {
+  id: "uni1",
+  title: "Spring MBU",
+  timezone: "America/New_York",
+  startDate: "2026-06-01T12:00:00.000Z",
+  endDate: null,
+  registrationOpensAt: null,
+  registrationClosesAt: "2026-05-25T23:59:59.000Z",
+  location: sampleUniversity.location,
+  periods: [
+    {
+      periodId: "p1",
+      label: "Morning",
+      startsAt: "2026-06-01T08:00:00.000Z",
+      endsAt: "2026-06-01T12:00:00.000Z",
+    },
+  ],
+  classes: [
+    {
+      classId: "cls1",
+      badgeSlug: "camping",
+      badgeTitle: "Camping",
+      eagleRequired: true,
+      periodIds: ["p1"],
+      room: "Room A",
+      notes: null,
+      capacity: 20,
+      enrolledCount: 5,
+      seatsRemaining: 15,
+      waitlistCount: 0,
+      counselors: [{ displayName: "Alex Counselor" }],
+    },
+  ],
+};
+
 const universitiesService: UniversitiesService = {
+  getPublic: universityId => {
+    if (universityId === "draft-uni") {
+      return Promise.reject(new NotFoundError("University not found"));
+    }
+    if (universityId === "missing-uni") {
+      return Promise.reject(new NotFoundError("University not found"));
+    }
+    return Promise.resolve({ ...samplePublicUniversity, id: universityId });
+  },
   create: (_caller, request) =>
     Promise.resolve({
       ...sampleUniversity,
@@ -248,6 +293,66 @@ describe("universities-api routes", () => {
       authed("/api/universities/uni1/classes/cls1", "DELETE"),
     );
     expect(response.status).toBe(204);
+  });
+});
+
+describe("universities-api public route", () => {
+  const publicApp = () =>
+    createApp({
+      universitiesService,
+      periodsService,
+      classesService,
+      verifyToken: verified,
+    });
+
+  it("GET /api/universities/:id/public returns the public DTO without auth", async () => {
+    const response = await handleRequest(
+      publicApp(),
+      new Request("http://localhost/api/universities/uni1/public", {
+        method: "GET",
+      }),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body["id"]).toBe("uni1");
+    expect(body["title"]).toBe("Spring MBU");
+    expect(body).not.toHaveProperty("createdByUid");
+    expect(body).not.toHaveProperty("status");
+    const counselors = (
+      body["classes"] as { counselors: Record<string, unknown>[] }[]
+    )[0]?.counselors;
+    expect(counselors?.[0]).toEqual({ displayName: "Alex Counselor" });
+    expect(counselors?.[0]).not.toHaveProperty("uid");
+    expect(counselors?.[0]).not.toHaveProperty("bsaId");
+  });
+
+  it("returns 404 for draft and missing ids with identical bodies", async () => {
+    const app = publicApp();
+    const draftResponse = await handleRequest(
+      app,
+      new Request("http://localhost/api/universities/draft-uni/public", {
+        method: "GET",
+      }),
+    );
+    const missingResponse = await handleRequest(
+      app,
+      new Request("http://localhost/api/universities/missing-uni/public", {
+        method: "GET",
+      }),
+    );
+    expect(draftResponse.status).toBe(404);
+    expect(missingResponse.status).toBe(404);
+    expect(await draftResponse.json()).toEqual(await missingResponse.json());
+  });
+
+  it("sets Cache-Control: no-store on the public response", async () => {
+    const response = await handleRequest(
+      publicApp(),
+      new Request("http://localhost/api/universities/uni1/public", {
+        method: "GET",
+      }),
+    );
+    expect(response.headers.get("cache-control")).toBe("no-store");
   });
 });
 

--- a/functions/src/universities-api/app.ts
+++ b/functions/src/universities-api/app.ts
@@ -14,6 +14,7 @@ import {
   PeriodsPutRequestSchema,
   PeriodsResponseSchema,
 } from "./schemas/period-schemas.js";
+import { PublicUniversityResponseSchema } from "./schemas/public-schemas.js";
 import {
   UniversityCreateRequestSchema,
   UniversityListResponseSchema,
@@ -29,8 +30,9 @@ import type { PartialUniversitiesApiServices } from "./types/services.js";
  * Create the universities-api Elysia app with injectable dependencies.
  *
  * Firebase hosting routes /api/universities/** → universitiesApi function.
- * Every route runs behind `requireAuth`; scoped writes call assertChancellorOf
- * inside the relevant services.
+ * Authenticated routes run behind `requireAuth`; scoped writes call
+ * assertChancellorOf inside the relevant services. The public event read is
+ * unauthenticated (link-only access).
  */
 export function createApp(services?: PartialUniversitiesApiServices) {
   const universities = services?.universitiesService ?? defaultUniversities;
@@ -40,6 +42,14 @@ export function createApp(services?: PartialUniversitiesApiServices) {
 
   return new Elysia({ adapter: node(), prefix: "/api" })
     .onError(mapError)
+    .get(
+      "/universities/:id/public",
+      async ({ params, set }) => {
+        set.headers["cache-control"] = "no-store";
+        return universities.getPublic(params.id);
+      },
+      { response: PublicUniversityResponseSchema },
+    )
     .resolve(requireAuth(verifyToken))
     .post(
       "/universities",

--- a/functions/src/universities-api/schemas/public-schemas.ts
+++ b/functions/src/universities-api/schemas/public-schemas.ts
@@ -1,0 +1,40 @@
+import { t, type Static } from "elysia";
+import { PeriodResponseSchema } from "./period-schemas.js";
+import { LocationSchema } from "./university-schemas.js";
+
+export const PublicClassCounselorSchema = t.Object({
+  displayName: t.String(),
+});
+export type PublicClassCounselor = Static<typeof PublicClassCounselorSchema>;
+
+export const PublicClassResponseSchema = t.Object({
+  classId: t.String(),
+  badgeSlug: t.String(),
+  badgeTitle: t.String(),
+  eagleRequired: t.Boolean(),
+  periodIds: t.Array(t.String()),
+  room: t.Union([t.String(), t.Null()]),
+  notes: t.Union([t.String(), t.Null()]),
+  capacity: t.Number(),
+  enrolledCount: t.Number(),
+  seatsRemaining: t.Number(),
+  waitlistCount: t.Number(),
+  counselors: t.Array(PublicClassCounselorSchema),
+});
+export type PublicClassResponse = Static<typeof PublicClassResponseSchema>;
+
+export const PublicUniversityResponseSchema = t.Object({
+  id: t.String(),
+  title: t.String(),
+  timezone: t.String(),
+  startDate: t.String(),
+  endDate: t.Union([t.String(), t.Null()]),
+  registrationOpensAt: t.Union([t.String(), t.Null()]),
+  registrationClosesAt: t.String(),
+  location: LocationSchema,
+  periods: t.Array(PeriodResponseSchema),
+  classes: t.Array(PublicClassResponseSchema),
+});
+export type PublicUniversityResponse = Static<
+  typeof PublicUniversityResponseSchema
+>;

--- a/functions/src/universities-api/services/universities/index.test.ts
+++ b/functions/src/universities-api/services/universities/index.test.ts
@@ -1,0 +1,167 @@
+import { Timestamp, type Firestore } from "firebase-admin/firestore";
+import { describe, expect, it } from "bun:test";
+import type { ClassDocument } from "../../../collections/classes.js";
+import type { UniversityDocument } from "../../../collections/universities.js";
+import { NotFoundError } from "../../../shared-api/errors/http-error.js";
+import { UniversitiesServiceImpl } from "./index.js";
+
+const baseUniversity: UniversityDocument = {
+  title: "Spring MBU",
+  status: "published",
+  timezone: "America/New_York",
+  startDate: Timestamp.fromDate(new Date("2026-06-01T12:00:00.000Z")),
+  endDate: null,
+  registrationOpensAt: null,
+  registrationClosesAt: Timestamp.fromDate(
+    new Date("2026-05-25T23:59:59.000Z"),
+  ),
+  location: {
+    name: "Scout Hall",
+    address: "1 Main St",
+    city: "Anytown",
+    state: "NY",
+    zip: "12345",
+  },
+  periods: [
+    {
+      periodId: "p1",
+      label: "Morning",
+      startsAt: Timestamp.fromDate(new Date("2026-06-01T08:00:00.000Z")),
+      endsAt: Timestamp.fromDate(new Date("2026-06-01T12:00:00.000Z")),
+    },
+  ],
+  createdByUid: "u1",
+  submittedAt: null,
+  publishedAt: null,
+  reviewNote: null,
+  billing: null,
+  createdAt: Timestamp.fromDate(new Date("2026-07-01T00:00:00.000Z")),
+  updatedAt: Timestamp.fromDate(new Date("2026-07-01T00:00:00.000Z")),
+};
+
+const sampleClass: ClassDocument = {
+  badgeSlug: "camping",
+  badgeTitle: "Camping",
+  eagleRequired: true,
+  periodIds: ["p1"],
+  capacity: 20,
+  enrolledCount: 5,
+  waitlistCount: 2,
+  room: "Room A",
+  notes: "Bring gear",
+  counselors: [
+    {
+      uid: "c1",
+      displayName: "Alex Counselor",
+      bsaId: "123456789",
+      disclaimerAcceptedAt: Timestamp.fromDate(
+        new Date("2026-07-01T00:00:00.000Z"),
+      ),
+      disclaimerVersion: "2026-07-03",
+    },
+  ],
+  createdAt: Timestamp.fromDate(new Date("2026-07-01T00:00:00.000Z")),
+  updatedAt: Timestamp.fromDate(new Date("2026-07-01T00:00:00.000Z")),
+};
+
+function mockFirestore(options: {
+  university: UniversityDocument | null;
+  classes?: Array<{ id: string; data: ClassDocument }>;
+}): Firestore {
+  const universityRef = {
+    get: () =>
+      Promise.resolve({
+        exists: options.university !== null,
+        data: () => options.university,
+        id: "uni1",
+      }),
+  };
+
+  const classDocs = options.classes ?? [];
+  const classesCollection = {
+    orderBy: () => ({
+      get: () =>
+        Promise.resolve({
+          docs: classDocs.map(entry => ({
+            id: entry.id,
+            data: () => entry.data,
+          })),
+        }),
+    }),
+  };
+
+  return {
+    collection: (path: string) => {
+      if (path === "universities") {
+        return { doc: () => universityRef };
+      }
+      if (path.endsWith("/classes")) {
+        return classesCollection;
+      }
+      throw new Error(`unexpected collection path: ${path}`);
+    },
+  } as unknown as Firestore;
+}
+
+describe("UniversitiesServiceImpl.getPublic", () => {
+  it("maps a published university to the public DTO", async () => {
+    const service = new UniversitiesServiceImpl(
+      mockFirestore({
+        university: baseUniversity,
+        classes: [{ id: "cls1", data: sampleClass }],
+      }),
+    );
+
+    const result = await service.getPublic("uni1");
+
+    expect(result.id).toBe("uni1");
+    expect(result.title).toBe("Spring MBU");
+    expect(result.periods).toHaveLength(1);
+    expect(result.classes).toHaveLength(1);
+    expect(result.classes[0]).toMatchObject({
+      classId: "cls1",
+      badgeTitle: "Camping",
+      capacity: 20,
+      enrolledCount: 5,
+      seatsRemaining: 15,
+      waitlistCount: 2,
+      counselors: [{ displayName: "Alex Counselor" }],
+    });
+    expect(result).not.toHaveProperty("createdByUid");
+    expect(result).not.toHaveProperty("status");
+    expect(result.classes[0]).not.toHaveProperty("bsaId");
+    expect(result.classes[0]?.counselors[0]).not.toHaveProperty("uid");
+  });
+
+  const nonPublicStatuses = [
+    "draft",
+    "submitted",
+    "needs_review",
+    "rejected",
+    "closed",
+  ] as const;
+
+  for (const status of nonPublicStatuses) {
+    it(`throws NotFoundError for a ${status} university`, async () => {
+      const service = new UniversitiesServiceImpl(
+        mockFirestore({
+          university: { ...baseUniversity, status },
+        }),
+      );
+
+      await expect(service.getPublic("uni1")).rejects.toBeInstanceOf(
+        NotFoundError,
+      );
+    });
+  }
+
+  it("throws NotFoundError for a missing university", async () => {
+    const service = new UniversitiesServiceImpl(
+      mockFirestore({ university: null }),
+    );
+
+    await expect(service.getPublic("missing")).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+  });
+});

--- a/functions/src/universities-api/services/universities/index.ts
+++ b/functions/src/universities-api/services/universities/index.ts
@@ -28,6 +28,7 @@ import type {
   ClassResponse,
   UniversityDetailResponse,
 } from "../../schemas/class-schemas.js";
+import type { PublicUniversityResponse } from "../../schemas/public-schemas.js";
 import type {
   UniversityCreateRequest,
   UniversityListResponse,
@@ -85,6 +86,26 @@ function toClassResponse(classId: string, doc: ClassDocument): ClassResponse {
     })),
     createdAt: toIso(doc.createdAt) ?? "",
     updatedAt: toIso(doc.updatedAt) ?? "",
+  };
+}
+
+function toPublicClassResponse(
+  classId: string,
+  doc: ClassDocument,
+): PublicUniversityResponse["classes"][number] {
+  return {
+    classId,
+    badgeSlug: doc.badgeSlug,
+    badgeTitle: doc.badgeTitle,
+    eagleRequired: doc.eagleRequired,
+    periodIds: doc.periodIds,
+    room: doc.room,
+    notes: doc.notes,
+    capacity: doc.capacity,
+    enrolledCount: doc.enrolledCount,
+    seatsRemaining: Math.max(0, doc.capacity - doc.enrolledCount),
+    waitlistCount: doc.waitlistCount,
+    counselors: doc.counselors.map(c => ({ displayName: c.displayName })),
   };
 }
 
@@ -335,6 +356,50 @@ export class UniversitiesServiceImpl implements UniversitiesService {
     );
 
     return { universities: summaries };
+  }
+
+  async getPublic(universityId: string): Promise<PublicUniversityResponse> {
+    const reference = this.db()
+      .collection(UNIVERSITIES_COLLECTION)
+      .doc(universityId);
+    const snapshot = await reference.get();
+    if (!snapshot.exists) {
+      throw new NotFoundError("University not found");
+    }
+    const doc = snapshot.data() as UniversityDocument;
+    // Allowlist, not denylist: only a published event is publicly viewable.
+    // Every other status (draft/submitted/needs_review/rejected/closed) 404s
+    // with the same body so a probe can't confirm a hidden or rejected event.
+    if (doc.status !== "published") {
+      throw new NotFoundError("University not found");
+    }
+
+    const classesSnapshot = await this.db()
+      .collection(
+        `${UNIVERSITIES_COLLECTION}/${universityId}/${CLASSES_SUBCOLLECTION}`,
+      )
+      .orderBy("createdAt")
+      .get();
+
+    return {
+      id: universityId,
+      title: doc.title,
+      timezone: doc.timezone,
+      startDate: toIso(doc.startDate) ?? "",
+      endDate: toIso(doc.endDate),
+      registrationOpensAt: toIso(doc.registrationOpensAt),
+      registrationClosesAt: toIso(doc.registrationClosesAt) ?? "",
+      location: doc.location,
+      periods: doc.periods.map(p => ({
+        periodId: p.periodId,
+        label: p.label,
+        startsAt: toIso(p.startsAt) ?? "",
+        endsAt: toIso(p.endsAt) ?? "",
+      })),
+      classes: classesSnapshot.docs.map(classDoc =>
+        toPublicClassResponse(classDoc.id, classDoc.data() as ClassDocument),
+      ),
+    };
   }
 
   async getDetail(

--- a/functions/src/universities-api/services/universities/interface.ts
+++ b/functions/src/universities-api/services/universities/interface.ts
@@ -1,5 +1,6 @@
 import type { Caller } from "../../../shared-api/types/caller.js";
 import type { UniversityDetailResponse } from "../../schemas/class-schemas.js";
+import type { PublicUniversityResponse } from "../../schemas/public-schemas.js";
 import type {
   UniversityCreateRequest,
   UniversityListResponse,
@@ -8,6 +9,7 @@ import type {
 } from "../../schemas/university-schemas.js";
 
 export interface UniversitiesService {
+  getPublic(universityId: string): Promise<PublicUniversityResponse>;
   create(
     caller: Caller,
     request: UniversityCreateRequest,


### PR DESCRIPTION
Closes #83.

Public, unauthenticated read surface for events — reachable only via a chancellor-shared link. Implements the design locked in the [#83 interview](https://github.com/markgoho/mbu/issues/83#issuecomment-4879956659).

## Backend
- **`GET /api/universities/:id/public`** on the existing `universitiesApi` function, positioned **outside** the `requireAuth` resolve (no auth). Reuses the existing hosting rewrite — no `firebase.json` change.
- **Distinct public DTO** (`public-schemas.ts`) is the trust boundary: strips `createdByUid`, internal timestamps, raw `status`, and every counselor field except **`displayName`** — notably drops `bsaId` (Scouting America PII), counselor `uid`, and disclaimer metadata. Adds derived `seatsRemaining`.
- **Allowlist status gate:** only `published` is publicly viewable; `draft | submitted | needs_review | rejected | closed` all return an **identical 404** so a probe can't confirm a hidden or rejected event.
- **`Cache-Control: no-store`** — live seat counts, so the "seats filling up" signal stays accurate.

## Frontend
- Guard-free **`/e/:id`** route + `PublicEvent` component built on **`httpResource`** (matches the repo convention). Cancels superseded requests (no stale-response race) and renders distinct **not-found (404)** vs **generic-error** states — no blank-page silent failure.
- **"Sign in to register"** CTA carrying `returnTo=/e/:id`, so an unauthenticated viewer lands back on the event after auth.
- Shared **`safeReturnTo()`** open-redirect guard (rejects `//host`), used by both `sign-in` and `requireUnauth`.

## Tests
- Service: public DTO mapping + PII-absence assertions; all five non-published statuses → 404.
- Route: unauthenticated 200, identical-body 404s, `no-store` header, PII stripped.
- Component: seat counts + CTA `returnTo`, 404 message, and a 500 → generic-error (guards against silent blank page).

All gates green via `bun`: functions 58 tests + lint + typecheck + typecheck:tests; app 29 tests + lint + build.

## Dependencies / notes
- **#87** owns the publish transition — until it lands, no event reaches `published`, so `/e/:id` 404s for all real events (intended per the locked design).
- **#84** owns the post-auth registration flow behind the CTA and populates `enrolledCount`/`waitlistCount`.
