### PR TITLE
Add Cloud Functions CI: PR gate + merge deploy (#110)

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -10,6 +10,7 @@ on:
       - "Dockerfile"
       - ".github/workflows/docker-image.yml"
       - "app/**"
+      - "functions/**"
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/functions-deploy-merge.yml
+++ b/.github/workflows/functions-deploy-merge.yml
@@ -1,0 +1,79 @@
+name: Deploy Cloud Functions on merge
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - trunk
+    paths:
+      - "functions/**"
+      - "firebase.json"
+      - ".firebaserc"
+      - ".github/workflows/functions-deploy-merge.yml"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}:trunk
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+      - name: Install dependencies
+        working-directory: functions
+        run: npm ci
+      - name: Lint functions
+        working-directory: functions
+        run: npm run lint
+
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}:trunk
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+      - name: Install dependencies
+        working-directory: functions
+        run: npm ci
+      - name: Test functions
+        working-directory: functions
+        run: npm test
+
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}:trunk
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+      - name: Install dependencies
+        working-directory: functions
+        run: npm ci
+      - name: Build functions
+        working-directory: functions
+        run: npm run build
+
+  deploy:
+    needs: [lint, test, build]
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}:trunk
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+      - name: Install root dependencies
+        run: bun install
+      - name: Install functions dependencies
+        working-directory: functions
+        run: npm ci
+      - name: Deploy functions
+        env:
+          FIREBASE_SA: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_MERIT_BADGE_UNIVERSITY }}
+        run: |
+          echo "$FIREBASE_SA" > "$RUNNER_TEMP/sa.json"
+          export GOOGLE_APPLICATION_CREDENTIALS="$RUNNER_TEMP/sa.json"
+          bunx firebase deploy --only functions --project merit-badge-university --non-interactive --force

--- a/.github/workflows/functions-pull-request.yml
+++ b/.github/workflows/functions-pull-request.yml
@@ -1,0 +1,64 @@
+name: Check Cloud Functions on PR
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    paths:
+      - "functions/**"
+      - "firebase.json"
+      - ".firebaserc"
+      - ".github/workflows/functions-pull-request.yml"
+
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  lint:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}:trunk
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+      - name: Install dependencies
+        working-directory: functions
+        run: npm ci
+      - name: Lint functions
+        working-directory: functions
+        run: npm run lint
+
+  test:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}:trunk
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+      - name: Install dependencies
+        working-directory: functions
+        run: npm ci
+      - name: Test functions
+        working-directory: functions
+        run: npm test
+
+  build:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}:trunk
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+      - name: Install dependencies
+        working-directory: functions
+        run: npm ci
+      - name: Build functions
+        working-directory: functions
+        run: npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Set versions for our tools as arguments
 ARG HUGO_VERSION=0.159.2
-ARG BUN_VERSION=1.3.11
+ARG BUN_VERSION=1.3.14
 ARG PLAYWRIGHT_VERSION=1.61.0
 
 # 1. Install base dependencies and Java 21 (required for Firebase emulators - firebase-tools requires Java 21+)
@@ -28,8 +28,8 @@ RUN git config --global --add safe.directory /__w/mbu/mbu && \
   git config --system --add safe.directory /__w/mbu/mbu && \
   git config --system --add core.quotepath false
 
-# Install Node.js 22.x LTS (firebase-tools, sharp, and other native deps)
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+# Install Node.js 24.x LTS (firebase-tools, sharp, and other native deps)
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
   && apt-get install -y nodejs
 
 # 2. Install Bun


### PR DESCRIPTION
Closes #110.

## Problem
There was **no CI for the `functions/` codebase** — only Hugo and the Angular app were gated/deployed via GitHub Actions. Cloud Functions were only ever deployed manually with `firebase deploy`. #85 introduced the first functions secret (`MAILGUN_API_KEY`), making a repeatable, gated deploy worthwhile.

## Changes
- **`functions-pull-request.yml`** (new) — on PRs touching `functions/**`, runs parallel **lint / test / build** in the CI container (`npm ci`). **No deploy step.**
- **`functions-deploy-merge.yml`** (new) — on push to `trunk`, runs the same lint/test/build gate, then a `deploy` job (`needs: [lint, test, build]`) that runs `firebase deploy --only functions` authed via the existing `FIREBASE_SERVICE_ACCOUNT_MERIT_BADGE_UNIVERSITY` secret (written to a temp file → `GOOGLE_APPLICATION_CREDENTIALS`). `concurrency` serializes deploys.
- **`firebase-hosting-merge.yml`** — added `functions/**` to `paths-ignore` so a functions-only push no longer triggers a redundant Hugo main-site redeploy.
- **`Dockerfile`** — bumped CI image to **Node 24** (matches the functions runtime) and **Bun 1.3.14**.

## Deploy semantics
- PR → build/test/lint only, **never deploys functions**.
- Merge to `trunk` → build/test/lint + deploy all functions (`healthApi`, `usersApi`, `universitiesApi`, `registrationsApi` — single `default` codebase).

## Acceptance criteria
- [x] PRs touching `functions/**` run lint + test + build and block merge on failure.
- [x] Merge to `trunk` redeploys all functions only after lint/test/build pass.
- [x] Deploy authenticates with the existing Firebase service-account secret; no new long-lived creds.
- [x] Overlapping deploys are cancelled/queued via `concurrency`.

## Notes
- `MAILGUN_API_KEY` must exist in Google Secret Manager before the first deploy that includes `registrationsApi`, or deploy fails (tracked in #106).
- The Dockerfile bump changes the image shared by *all* CI; app + Hugo jobs should be re-verified green on the rebuilt `:trunk` image.