### PR TITLE
Add rosters + CSV export for chancellors/counselors — issue #86

### DIFF
--- a/app/e2e/tests/roster.spec.ts
+++ b/app/e2e/tests/roster.spec.ts
@@ -1,0 +1,133 @@
+import type { RosterResponse } from '../../src/app/api-types/registrations-api.types';
+import type { UniversityListResponse } from '../../src/app/api-types/universities-api.types';
+import { expect, test } from '../fixtures/auth.fixture';
+
+/**
+ * Chancellor/counselor roster view, fully mocked except the Auth emulator.
+ * Mirrors registration.spec.ts's use of the verifiedPage fixture.
+ */
+
+const UNIVERSITY_ID = 'summer-2026';
+
+function buildRoster(): RosterResponse {
+  return {
+    university: {
+      title: 'Summer 2026 MBU',
+      startDate: '2026-07-10T13:00:00.000Z',
+      endDate: '2026-07-10T20:00:00.000Z',
+      location: {
+        name: 'Central High School',
+        address: '100 Main St',
+        city: 'Springfield',
+        state: 'IL',
+        zip: '62701',
+      },
+      timezone: 'America/Chicago',
+    },
+    classRosters: [
+      {
+        class: {
+          classId: 'cls-camping',
+          badgeTitle: 'Camping',
+          periodLabels: ['Morning'],
+          room: 'Room A',
+          capacity: 2,
+          enrolledCount: 1,
+          waitlistCount: 1,
+          counselorNames: ['Pat Counselor'],
+        },
+        enrolled: [
+          {
+            scoutId: 'scout-alex',
+            scoutFirstName: 'Alex',
+            scoutLastName: 'Scout',
+            scoutUnit: 'Troop 1',
+            accommodations: null,
+            parentName: 'Jamie Guardian',
+            parentEmail: 'jamie@example.com',
+            consentReceived: true,
+            status: 'enrolled',
+          },
+        ],
+        waitlisted: [
+          {
+            scoutId: 'scout-jamie',
+            scoutFirstName: 'Jamie',
+            scoutLastName: 'Scout',
+            scoutUnit: null,
+            accommodations: 'Peanut allergy',
+            parentName: 'Robin Guardian',
+            parentEmail: 'robin@example.com',
+            consentReceived: true,
+            status: 'waitlisted',
+          },
+        ],
+      },
+      {
+        class: {
+          classId: 'cls-fishing',
+          badgeTitle: 'Fishing',
+          periodLabels: ['Afternoon'],
+          room: null,
+          capacity: 5,
+          enrolledCount: 0,
+          waitlistCount: 0,
+          counselorNames: [],
+        },
+        enrolled: [],
+        waitlisted: [],
+      },
+    ],
+  };
+}
+
+test.describe('roster page', () => {
+  test('renders enrolled/waitlisted tables per class, including an empty class', async ({
+    verifiedPage: page,
+  }) => {
+    await page.route(`**/api/registrations/${UNIVERSITY_ID}/roster`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(buildRoster()),
+      }),
+    );
+
+    await page.goto(`/universities/${UNIVERSITY_ID}/roster`);
+
+    await expect(page.getByRole('heading', { name: 'Summer 2026 MBU — Rosters' })).toBeVisible();
+
+    const campingSection = page.locator('.roster-page__class', { hasText: 'Camping' });
+    await expect(campingSection.getByText('Alex', { exact: true })).toBeVisible();
+    await expect(campingSection.getByText('Jamie', { exact: true })).toBeVisible();
+    await expect(campingSection.getByRole('button', { name: 'Export CSV' })).toBeVisible();
+
+    const fishingSection = page.locator('.roster-page__class', { hasText: 'Fishing' });
+    await expect(fishingSection.getByText('No one enrolled.')).toBeVisible();
+
+    await expect(page.getByRole('button', { name: 'Print' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Export event CSV' })).toBeVisible();
+  });
+
+  test('redirects to the dashboard with a flash message on 403', async ({ verifiedPage: page }) => {
+    await page.route(`**/api/registrations/${UNIVERSITY_ID}/roster`, (route) =>
+      route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Forbidden' }),
+      }),
+    );
+    await page.route('**/api/universities/mine', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ universities: [] } satisfies UniversityListResponse),
+      }),
+    );
+
+    await page.goto(`/universities/${UNIVERSITY_ID}/roster`);
+
+    await page.waitForURL('**/universities');
+    await expect(page.getByText('You do not have access to those rosters.')).toBeVisible();
+  });
+});

--- a/app/proxy.conf.json
+++ b/app/proxy.conf.json
@@ -13,5 +13,10 @@
     "target": "http://localhost:5001/merit-badge-university/us-east4/universitiesApi",
     "secure": false,
     "changeOrigin": true
+  },
+  "/api/registrations": {
+    "target": "http://localhost:5001/merit-badge-university/us-east4/registrationsApi",
+    "secure": false,
+    "changeOrigin": true
   }
 }

--- a/app/src/app/api-types/registrations-api.types.ts
+++ b/app/src/app/api-types/registrations-api.types.ts
@@ -20,3 +20,47 @@ export interface RegistrationResponse {
 export interface ScheduleResponse {
   registrations: RegistrationResponse[];
 }
+
+export interface RosterRow {
+  scoutId: string;
+  scoutFirstName: string;
+  scoutLastName: string;
+  scoutUnit: string | null;
+  accommodations: string | null;
+  parentName: string;
+  parentEmail: string;
+  consentReceived: boolean;
+  status: RegistrationStatus;
+}
+
+export interface ClassRoster {
+  class: {
+    classId: string;
+    badgeTitle: string;
+    periodLabels: string[];
+    room: string | null;
+    capacity: number;
+    enrolledCount: number;
+    waitlistCount: number;
+    counselorNames: string[];
+  };
+  enrolled: RosterRow[];
+  waitlisted: RosterRow[];
+}
+
+export interface RosterResponse {
+  university: {
+    title: string;
+    startDate: string;
+    endDate: string | null;
+    location: {
+      name: string;
+      address: string;
+      city: string;
+      state: string;
+      zip: string;
+    };
+    timezone: string;
+  };
+  classRosters: ClassRoster[];
+}

--- a/app/src/app/app.routes.ts
+++ b/app/src/app/app.routes.ts
@@ -59,6 +59,11 @@ export const routes: Routes = [
             (m) => m.UniversityEditor,
           ),
       },
+      {
+        path: ':id/roster',
+        loadComponent: () =>
+          import('./universities/roster-page/roster-page').then((m) => m.RosterPage),
+      },
     ],
   },
   {

--- a/app/src/app/lib/roster-csv.spec.ts
+++ b/app/src/app/lib/roster-csv.spec.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import type { ClassRoster, RosterResponse, RosterRow } from '../api-types/registrations-api.types';
+import { classRosterToCsv, eventRosterToCsv } from './roster-csv';
+
+function row(overrides: Partial<RosterRow> = {}): RosterRow {
+  return {
+    scoutId: 'scout1',
+    scoutFirstName: 'Alex',
+    scoutLastName: 'Smith',
+    scoutUnit: 'Troop 1',
+    accommodations: null,
+    parentName: 'Jamie Smith',
+    parentEmail: 'jamie@example.com',
+    consentReceived: true,
+    status: 'enrolled',
+    ...overrides,
+  };
+}
+
+function classRoster(overrides: Partial<ClassRoster> = {}): ClassRoster {
+  return {
+    class: {
+      classId: 'cls1',
+      badgeTitle: 'Camping',
+      periodLabels: ['Period 1'],
+      room: 'Room A',
+      capacity: 10,
+      enrolledCount: 1,
+      waitlistCount: 0,
+      counselorNames: ['Pat Counselor'],
+    },
+    enrolled: [row()],
+    waitlisted: [],
+    ...overrides,
+  };
+}
+
+describe('classRosterToCsv', () => {
+  it('lists the class column header row', () => {
+    const csv = classRosterToCsv(classRoster({ enrolled: [], waitlisted: [] }));
+    expect(csv).toBe(
+      'Present,Last Name,First Name,Unit,Status,Waitlist Position,Accommodations,Parent Name,Parent Email,Consent',
+    );
+  });
+
+  it('leaves the Present column empty for enrolled rows', () => {
+    const csv = classRosterToCsv(classRoster());
+    const [, dataLine] = csv.split('\r\n');
+    expect(dataLine).toBe(',Smith,Alex,Troop 1,enrolled,,,Jamie Smith,jamie@example.com,Yes');
+  });
+
+  it('numbers waitlisted rows by position, 1-indexed', () => {
+    const csv = classRosterToCsv(
+      classRoster({
+        enrolled: [],
+        waitlisted: [
+          row({ scoutId: 's1', scoutLastName: 'First' }),
+          row({ scoutId: 's2', scoutLastName: 'Second' }),
+        ],
+      }),
+    );
+    const lines = csv.split('\r\n');
+    expect(lines[1]).toContain(',First,');
+    expect(lines[1]?.split(',')[5]).toBe('1');
+    expect(lines[2]?.split(',')[5]).toBe('2');
+  });
+
+  it('escapes commas, quotes, and newlines per RFC 4180', () => {
+    const csv = classRosterToCsv(
+      classRoster({
+        enrolled: [row({ accommodations: 'Needs a "quiet" room, near exit\nand a chair' })],
+      }),
+    );
+    expect(csv).toContain('"Needs a ""quiet"" room, near exit\nand a chair"');
+  });
+});
+
+describe('eventRosterToCsv', () => {
+  function roster(overrides: Partial<RosterResponse> = {}): RosterResponse {
+    return {
+      university: {
+        title: 'Spring MBU',
+        startDate: '2026-06-01T12:00:00.000Z',
+        endDate: null,
+        location: { name: 'Scout Hall', address: '1 Main St', city: 'Anytown', state: 'NY', zip: '12345' },
+        timezone: 'America/New_York',
+      },
+      classRosters: [classRoster()],
+      ...overrides,
+    };
+  }
+
+  it('prefixes each row with Badge, Period(s), Room ahead of the class columns', () => {
+    const csv = eventRosterToCsv(roster());
+    const [header, dataLine] = csv.split('\r\n');
+    expect(header).toBe(
+      'Badge,Period(s),Room,Present,Last Name,First Name,Unit,Status,Waitlist Position,Accommodations,Parent Name,Parent Email,Consent',
+    );
+    expect(dataLine).toBe(
+      'Camping,Period 1,Room A,,Smith,Alex,Troop 1,enrolled,,,Jamie Smith,jamie@example.com,Yes',
+    );
+  });
+
+  it('joins multiple period labels with a semicolon', () => {
+    const csv = eventRosterToCsv(
+      roster({
+        classRosters: [
+          classRoster({
+            class: {
+              ...classRoster().class,
+              periodLabels: ['Period 1', 'Period 2'],
+            },
+          }),
+        ],
+      }),
+    );
+    expect(csv.split('\r\n')[1]).toContain('Period 1; Period 2');
+  });
+
+  it('includes every class, one after another', () => {
+    const csv = eventRosterToCsv(
+      roster({
+        classRosters: [
+          classRoster({ class: { ...classRoster().class, badgeTitle: 'Camping' } }),
+          classRoster({ class: { ...classRoster().class, badgeTitle: 'Archery' }, enrolled: [], waitlisted: [] }),
+        ],
+      }),
+    );
+    const lines = csv.split('\r\n');
+    expect(lines).toHaveLength(2); // header + 1 Camping row (Archery has no rows)
+    expect(lines[1]).toContain('Camping');
+  });
+});

--- a/app/src/app/lib/roster-csv.ts
+++ b/app/src/app/lib/roster-csv.ts
@@ -1,0 +1,77 @@
+import type { ClassRoster, RosterResponse, RosterRow } from '../api-types/registrations-api.types';
+
+/**
+ * RFC-4180 field escaping: quote a field if it contains a comma, quote, or
+ * line break, doubling any embedded quotes.
+ */
+function csvField(value: string): string {
+  if (/[",\r\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function csvRow(fields: string[]): string {
+  return fields.map(csvField).join(',');
+}
+
+function rosterRowFields(row: RosterRow, waitlistPosition: string): string[] {
+  return [
+    '', // Present
+    row.scoutLastName,
+    row.scoutFirstName,
+    row.scoutUnit ?? '',
+    row.status,
+    waitlistPosition,
+    row.accommodations ?? '',
+    row.parentName,
+    row.parentEmail,
+    row.consentReceived ? 'Yes' : 'No',
+  ];
+}
+
+const CLASS_COLUMNS = [
+  'Present',
+  'Last Name',
+  'First Name',
+  'Unit',
+  'Status',
+  'Waitlist Position',
+  'Accommodations',
+  'Parent Name',
+  'Parent Email',
+  'Consent',
+];
+
+const EVENT_COLUMNS = ['Badge', 'Period(s)', 'Room', ...CLASS_COLUMNS];
+
+/** CSV for a single class's roster (enrolled then waitlisted). */
+export function classRosterToCsv(classRoster: ClassRoster): string {
+  const lines = [csvRow(CLASS_COLUMNS)];
+  for (const row of classRoster.enrolled) {
+    lines.push(csvRow(rosterRowFields(row, '')));
+  }
+  classRoster.waitlisted.forEach((row, index) => {
+    lines.push(csvRow(rosterRowFields(row, String(index + 1))));
+  });
+  return lines.join('\r\n');
+}
+
+/** CSV for every class in the event, each row prefixed with the class's badge/period/room. */
+export function eventRosterToCsv(roster: RosterResponse): string {
+  const lines = [csvRow(EVENT_COLUMNS)];
+  for (const classRoster of roster.classRosters) {
+    const prefix = [
+      classRoster.class.badgeTitle,
+      classRoster.class.periodLabels.join('; '),
+      classRoster.class.room ?? '',
+    ];
+    for (const row of classRoster.enrolled) {
+      lines.push(csvRow([...prefix, ...rosterRowFields(row, '')]));
+    }
+    classRoster.waitlisted.forEach((row, index) => {
+      lines.push(csvRow([...prefix, ...rosterRowFields(row, String(index + 1))]));
+    });
+  }
+  return lines.join('\r\n');
+}

--- a/app/src/app/services/registrations.ts
+++ b/app/src/app/services/registrations.ts
@@ -4,6 +4,7 @@ import { firstValueFrom } from 'rxjs';
 import type {
   RegisterRequest,
   RegistrationResponse,
+  RosterResponse,
   ScheduleResponse,
 } from '../api-types/registrations-api.types';
 
@@ -29,6 +30,22 @@ export class Registrations {
 
   reloadSchedule(): void {
     this.schedule.reload();
+  }
+
+  /** Set by the roster page; drives the roster resource. */
+  readonly rosterUniversityId = signal<string | undefined>(undefined);
+
+  readonly roster = httpResource<RosterResponse>(() => {
+    const id = this.rosterUniversityId();
+    return id ? `/api/registrations/${id}/roster` : undefined;
+  });
+
+  openRoster(id: string): void {
+    if (this.rosterUniversityId() === id) {
+      this.roster.reload();
+    } else {
+      this.rosterUniversityId.set(id);
+    }
   }
 
   async register(

--- a/app/src/app/universities/roster-page/roster-page.css
+++ b/app/src/app/universities/roster-page/roster-page.css
@@ -1,0 +1,82 @@
+.roster-page {
+  max-width: 60rem;
+  margin: 2rem auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 0 1rem;
+}
+
+.roster-page__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.roster-page__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.roster-page__error {
+  color: var(--color-error);
+}
+
+.roster-page__empty {
+  color: var(--color-muted);
+}
+
+.roster-page__class {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding-block-end: 1rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.roster-page__class-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.roster-page__class-meta {
+  color: var(--color-muted);
+  font-size: 0.875rem;
+}
+
+.roster-page__counselors {
+  color: var(--color-muted);
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+.roster-page__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.roster-page__table th,
+.roster-page__table td {
+  text-align: left;
+  padding: 0.375rem 0.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+@media print {
+  .roster-page > a,
+  .roster-page button {
+    display: none;
+  }
+
+  .roster-page__class:not(:last-child) {
+    break-after: page;
+  }
+
+  .roster-page__class {
+    border-bottom: none;
+  }
+}

--- a/app/src/app/universities/roster-page/roster-page.html
+++ b/app/src/app/universities/roster-page/roster-page.html
@@ -1,0 +1,108 @@
+<main class="roster-page">
+  <a routerLink="/universities">← Back to dashboard</a>
+
+  @if (roster.isLoading()) {
+    <p>Loading…</p>
+  } @else if (loadError(); as message) {
+    <p class="roster-page__error" role="alert">{{ message }}</p>
+  } @else if (roster.error()) {
+    <!-- 403 — the constructor effect is redirecting to the dashboard. -->
+  } @else if (roster.value(); as data) {
+    <header class="roster-page__header">
+      <h1>{{ data.university.title }} — Rosters</h1>
+      <div class="roster-page__actions">
+        <button type="button" (click)="print()">Print</button>
+        <button type="button" (click)="exportEventCsv()">Export event CSV</button>
+      </div>
+    </header>
+
+    @if (data.classRosters.length === 0) {
+      <p class="roster-page__empty">No classes in this event yet.</p>
+    }
+
+    @for (classRoster of data.classRosters; track classRoster.class.classId) {
+      <section class="roster-page__class">
+        <header class="roster-page__class-header">
+          <h2>{{ classRoster.class.badgeTitle }}</h2>
+          <span class="roster-page__class-meta">
+            {{ classRoster.class.periodLabels.join(', ') }}
+            @if (classRoster.class.room) {
+              · {{ classRoster.class.room }}
+            }
+            · {{ classRoster.class.enrolledCount }}/{{ classRoster.class.capacity }} enrolled
+            @if (classRoster.class.waitlistCount > 0) {
+              · {{ classRoster.class.waitlistCount }} waitlisted
+            }
+          </span>
+          <button type="button" (click)="exportClassCsv(classRoster)">Export CSV</button>
+        </header>
+
+        @if (classRoster.class.counselorNames.length > 0) {
+          <p class="roster-page__counselors">Counselors: {{ classRoster.class.counselorNames.join(', ') }}</p>
+        }
+
+        <table class="roster-page__table">
+          <caption>Enrolled</caption>
+          <thead>
+            <tr>
+              <th scope="col">Present</th>
+              <th scope="col">Last Name</th>
+              <th scope="col">First Name</th>
+              <th scope="col">Unit</th>
+              <th scope="col">Accommodations</th>
+              <th scope="col">Parent</th>
+              <th scope="col">Consent</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (row of classRoster.enrolled; track row.scoutId) {
+              <tr>
+                <td></td>
+                <td>{{ row.scoutLastName }}</td>
+                <td>{{ row.scoutFirstName }}</td>
+                <td>{{ row.scoutUnit ?? '—' }}</td>
+                <td>{{ row.accommodations ?? '—' }}</td>
+                <td>{{ row.parentName }} ({{ row.parentEmail }})</td>
+                <td>{{ row.consentReceived ? 'Yes' : 'No' }}</td>
+              </tr>
+            } @empty {
+              <tr>
+                <td colspan="7">No one enrolled.</td>
+              </tr>
+            }
+          </tbody>
+        </table>
+
+        @if (classRoster.waitlisted.length > 0) {
+          <table class="roster-page__table">
+            <caption>Waitlisted</caption>
+            <thead>
+              <tr>
+                <th scope="col">Position</th>
+                <th scope="col">Last Name</th>
+                <th scope="col">First Name</th>
+                <th scope="col">Unit</th>
+                <th scope="col">Accommodations</th>
+                <th scope="col">Parent</th>
+                <th scope="col">Consent</th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (row of classRoster.waitlisted; track row.scoutId; let i = $index) {
+                <tr>
+                  <td>{{ i + 1 }}</td>
+                  <td>{{ row.scoutLastName }}</td>
+                  <td>{{ row.scoutFirstName }}</td>
+                  <td>{{ row.scoutUnit ?? '—' }}</td>
+                  <td>{{ row.accommodations ?? '—' }}</td>
+                  <td>{{ row.parentName }} ({{ row.parentEmail }})</td>
+                  <td>{{ row.consentReceived ? 'Yes' : 'No' }}</td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        }
+      </section>
+    }
+  }
+</main>

--- a/app/src/app/universities/roster-page/roster-page.spec.ts
+++ b/app/src/app/universities/roster-page/roster-page.spec.ts
@@ -1,0 +1,135 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { Component, inject } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router, RouterOutlet } from '@angular/router';
+import { render, screen } from '@testing-library/angular/zoneless';
+import { describe, expect, it } from 'vitest';
+import type { RosterResponse } from '../../api-types/registrations-api.types';
+import { Universities } from '../../services/universities';
+import { RosterPage } from './roster-page';
+
+@Component({
+  template: '<router-outlet />',
+  imports: [RouterOutlet],
+})
+class TestApp {}
+
+/** Stub for the redirect target — renders the flash message so tests assert on what the user sees. */
+@Component({
+  template: '<p>Dashboard{{ universities.flashMessage() ? ": " + universities.flashMessage() : "" }}</p>',
+})
+class DashboardStub {
+  protected readonly universities = inject(Universities);
+}
+
+const sampleRoster: RosterResponse = {
+  university: {
+    title: 'Spring MBU',
+    startDate: '2026-06-01T12:00:00.000Z',
+    endDate: null,
+    location: { name: 'Scout Hall', address: '1 Main St', city: 'Anytown', state: 'NY', zip: '12345' },
+    timezone: 'America/New_York',
+  },
+  classRosters: [
+    {
+      class: {
+        classId: 'cls1',
+        badgeTitle: 'Camping',
+        periodLabels: ['Period 1'],
+        room: 'Room A',
+        capacity: 10,
+        enrolledCount: 1,
+        waitlistCount: 1,
+        counselorNames: ['Pat Counselor'],
+      },
+      enrolled: [
+        {
+          scoutId: 'scout1',
+          scoutFirstName: 'Alex',
+          scoutLastName: 'Smith',
+          scoutUnit: 'Troop 1',
+          accommodations: null,
+          parentName: 'Jamie Smith',
+          parentEmail: 'jamie@example.com',
+          consentReceived: true,
+          status: 'enrolled',
+        },
+      ],
+      waitlisted: [
+        {
+          scoutId: 'scout2',
+          scoutFirstName: 'Sam',
+          scoutLastName: 'Jones',
+          scoutUnit: null,
+          accommodations: 'Wheelchair access',
+          parentName: 'Robin Jones',
+          parentEmail: 'robin@example.com',
+          consentReceived: false,
+          status: 'waitlisted',
+        },
+      ],
+    },
+    {
+      class: {
+        classId: 'cls2',
+        badgeTitle: 'Archery',
+        periodLabels: ['Period 2'],
+        room: null,
+        capacity: 5,
+        enrolledCount: 0,
+        waitlistCount: 0,
+        counselorNames: [],
+      },
+      enrolled: [],
+      waitlisted: [],
+    },
+  ],
+};
+
+const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('RosterPage', () => {
+  async function renderAt(path: string): Promise<HttpTestingController> {
+    await render(TestApp, {
+      providers: [
+        provideRouter([
+          { path: 'universities/:id/roster', component: RosterPage },
+          { path: 'universities', component: DashboardStub },
+        ]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+    await TestBed.inject(Router).navigateByUrl(path);
+    await flushMicrotasks();
+    return TestBed.inject(HttpTestingController);
+  }
+
+  it("renders each class's enrolled and waitlisted tables, including an empty class", async () => {
+    const httpMock = await renderAt('/universities/uni1/roster');
+
+    httpMock.expectOne('/api/registrations/uni1/roster').flush(sampleRoster);
+
+    expect(await screen.findByText('Spring MBU — Rosters')).toBeVisible();
+    expect(await screen.findByRole('heading', { name: 'Camping' })).toBeVisible();
+    expect(screen.getByText('Smith')).toBeVisible();
+    expect(screen.getByText('Jones')).toBeVisible();
+    expect(screen.getByRole('heading', { name: 'Archery' })).toBeVisible();
+    expect(screen.getByText('No one enrolled.')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Print' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Export event CSV' })).toBeVisible();
+    expect(screen.getAllByRole('button', { name: 'Export CSV' })).toHaveLength(2);
+  });
+
+  it('redirects to the dashboard with a flash message on 403', async () => {
+    const httpMock = await renderAt('/universities/uni1/roster');
+
+    httpMock
+      .expectOne('/api/registrations/uni1/roster')
+      .flush('forbidden', { status: 403, statusText: 'Forbidden' });
+    await flushMicrotasks();
+
+    expect(await screen.findByText('Dashboard: You do not have access to those rosters.')).toBeVisible();
+  });
+});

--- a/app/src/app/universities/roster-page/roster-page.ts
+++ b/app/src/app/universities/roster-page/roster-page.ts
@@ -1,0 +1,80 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import type { ClassRoster } from '../../api-types/registrations-api.types';
+import { classRosterToCsv, eventRosterToCsv } from '../../lib/roster-csv';
+import { Registrations } from '../../services/registrations';
+import { Universities } from '../../services/universities';
+
+@Component({
+  selector: 'app-roster-page',
+  imports: [RouterLink],
+  templateUrl: './roster-page.html',
+  styleUrl: './roster-page.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RosterPage {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly universities = inject(Universities);
+  private readonly registrations = inject(Registrations);
+
+  protected readonly universityId = signal('');
+
+  private readonly routeParams = toSignal(this.route.paramMap);
+
+  protected readonly roster = this.registrations.roster;
+
+  protected readonly loadError = computed(() => {
+    const error = this.roster.error();
+    if (!error) return null;
+    if (error instanceof HttpErrorResponse && error.status === 403) return null;
+    return 'Could not load rosters for this event.';
+  });
+
+  constructor() {
+    effect(() => {
+      const id = this.routeParams()?.get('id');
+      if (id) {
+        this.universityId.set(id);
+        this.registrations.openRoster(id);
+      }
+    });
+
+    effect(() => {
+      const error = this.roster.error();
+      if (error instanceof HttpErrorResponse && error.status === 403) {
+        this.universities.flashMessage.set('You do not have access to those rosters.');
+        void this.router.navigate(['/universities']);
+      }
+    });
+  }
+
+  protected print(): void {
+    globalThis.print();
+  }
+
+  protected exportEventCsv(): void {
+    const data = this.roster.value();
+    if (!data) return;
+    this.downloadCsv(eventRosterToCsv(data), `${data.university.title} - roster.csv`);
+  }
+
+  protected exportClassCsv(classRoster: ClassRoster): void {
+    this.downloadCsv(
+      classRosterToCsv(classRoster),
+      `${classRoster.class.badgeTitle} - roster.csv`,
+    );
+  }
+
+  private downloadCsv(content: string, filename: string): void {
+    const blob = new Blob([content], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+}

--- a/app/src/app/universities/university-editor/university-editor.html
+++ b/app/src/app/universities/university-editor/university-editor.html
@@ -9,6 +9,7 @@
     <header class="editor__header">
       <h1>{{ data.university.title }}</h1>
       <span class="editor__status">{{ data.university.status }}</span>
+      <a [routerLink]="['/universities', universityId(), 'roster']">View rosters</a>
       @if (data.university.status === 'draft') {
         <button type="button" class="editor__delete" (click)="deleteUniversity()">
           Delete draft

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -60,6 +60,14 @@
         { "fieldPath": "universityId", "order": "ASCENDING" },
         { "fieldPath": "status", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "registrations",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "universityId", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/functions/src/registrations-api/app.test.ts
+++ b/functions/src/registrations-api/app.test.ts
@@ -10,7 +10,10 @@ import {
 import type { TokenVerifier } from "../shared-api/plugins/require-auth.js";
 import { handleRequest } from "../test-utils/handle-request.js";
 import { createApp } from "./app.js";
-import type { RegistrationResponse } from "./schemas/registration-schemas.js";
+import type {
+  RegistrationResponse,
+  RosterResponse,
+} from "./schemas/registration-schemas.js";
 import type { RegistrationsService } from "./services/registrations/interface.js";
 
 const enrolledRegistration: RegistrationResponse = {
@@ -30,6 +33,76 @@ const waitlistedRegistration: RegistrationResponse = {
   status: "waitlisted",
   enrolledAt: null,
   waitlistedAt: "2026-07-02T00:00:00.000Z",
+};
+
+const sampleRoster: RosterResponse = {
+  university: {
+    title: "Spring MBU",
+    startDate: "2026-06-01T12:00:00.000Z",
+    endDate: null,
+    location: {
+      name: "Scout Hall",
+      address: "1 Main St",
+      city: "Anytown",
+      state: "NY",
+      zip: "12345",
+    },
+    timezone: "America/New_York",
+  },
+  classRosters: [
+    {
+      class: {
+        classId: "cls1",
+        badgeTitle: "Camping",
+        periodLabels: ["Period 1"],
+        room: "Room A",
+        capacity: 10,
+        enrolledCount: 1,
+        waitlistCount: 1,
+        counselorNames: ["Pat Counselor"],
+      },
+      enrolled: [
+        {
+          scoutId: "scout1",
+          scoutFirstName: "Alex",
+          scoutLastName: "Smith",
+          scoutUnit: "Troop 1",
+          accommodations: null,
+          parentName: "Jamie Smith",
+          parentEmail: "jamie@example.com",
+          consentReceived: true,
+          status: "enrolled",
+        },
+      ],
+      waitlisted: [
+        {
+          scoutId: "scout2",
+          scoutFirstName: "Sam",
+          scoutLastName: "Jones",
+          scoutUnit: null,
+          accommodations: "Wheelchair access",
+          parentName: "Robin Jones",
+          parentEmail: "robin@example.com",
+          consentReceived: true,
+          status: "waitlisted",
+        },
+      ],
+    },
+    {
+      class: {
+        classId: "cls2",
+        badgeTitle: "Archery",
+        periodLabels: ["Period 2"],
+        room: null,
+        capacity: 5,
+        enrolledCount: 0,
+        waitlistCount: 0,
+        counselorNames: [],
+      },
+      enrolled: [],
+      waitlisted: [],
+    },
+  ],
 };
 
 interface SetupOptions {
@@ -63,6 +136,7 @@ function setup({
     register: () => Promise.resolve(enrolledRegistration),
     cancel: () => Promise.resolve(),
     listSchedule: () => Promise.resolve({ registrations: [] }),
+    listRoster: () => Promise.resolve(sampleRoster),
     ...service,
   };
 
@@ -251,5 +325,40 @@ describe("GET /api/registrations/:universityId", () => {
       enrolledRegistration,
       waitlistedRegistration,
     ]);
+  });
+});
+
+describe("GET /api/registrations/:universityId/roster", () => {
+  it("returns the event's class rosters, including an empty class", async () => {
+    const { request } = setup();
+    const response = await request("/api/registrations/uni1/roster", "GET");
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as RosterResponse;
+    expect(body).toEqual(sampleRoster);
+  });
+
+  it("maps no accessible classes to 403", async () => {
+    const { request } = setup({
+      service: {
+        listRoster: () =>
+          Promise.reject(
+            new ForbiddenError(
+              "You do not have access to any classes in this event",
+            ),
+          ),
+      },
+    });
+    const response = await request("/api/registrations/uni1/roster", "GET");
+    expect(response.status).toBe(403);
+  });
+
+  it("maps a missing university to 404", async () => {
+    const { request } = setup({
+      service: {
+        listRoster: () => Promise.reject(new NotFoundError("University not found")),
+      },
+    });
+    const response = await request("/api/registrations/uni1/roster", "GET");
+    expect(response.status).toBe(404);
   });
 });

--- a/functions/src/registrations-api/app.ts
+++ b/functions/src/registrations-api/app.ts
@@ -6,6 +6,7 @@ import { verifyAuthToken } from "../shared-api/services/auth/verify-token.js";
 import {
   RegisterRequestSchema,
   RegistrationResponseSchema,
+  RosterResponseSchema,
   ScheduleResponseSchema,
 } from "./schemas/registration-schemas.js";
 import {
@@ -59,6 +60,12 @@ export function createApp(services?: PartialRegistrationsApiServices) {
         );
         set.status = 204;
       },
+    )
+    .get(
+      "/registrations/:universityId/roster",
+      ({ caller, params }) =>
+        registrations.listRoster(caller, params.universityId),
+      { response: RosterResponseSchema },
     )
     .get(
       "/registrations/:universityId",

--- a/functions/src/registrations-api/schemas/registration-schemas.ts
+++ b/functions/src/registrations-api/schemas/registration-schemas.ts
@@ -23,3 +23,50 @@ export const ScheduleResponseSchema = t.Object({
   registrations: t.Array(RegistrationResponseSchema),
 });
 export type ScheduleResponse = Static<typeof ScheduleResponseSchema>;
+
+export const RosterRowSchema = t.Object({
+  scoutId: t.String(),
+  scoutFirstName: t.String(),
+  scoutLastName: t.String(),
+  scoutUnit: t.Union([t.String(), t.Null()]),
+  accommodations: t.Union([t.String(), t.Null()]),
+  parentName: t.String(),
+  parentEmail: t.String(),
+  consentReceived: t.Boolean(),
+  status: t.Union([t.Literal("enrolled"), t.Literal("waitlisted")]),
+});
+export type RosterRow = Static<typeof RosterRowSchema>;
+
+export const ClassRosterSchema = t.Object({
+  class: t.Object({
+    classId: t.String(),
+    badgeTitle: t.String(),
+    periodLabels: t.Array(t.String()),
+    room: t.Union([t.String(), t.Null()]),
+    capacity: t.Number(),
+    enrolledCount: t.Number(),
+    waitlistCount: t.Number(),
+    counselorNames: t.Array(t.String()),
+  }),
+  enrolled: t.Array(RosterRowSchema),
+  waitlisted: t.Array(RosterRowSchema),
+});
+export type ClassRoster = Static<typeof ClassRosterSchema>;
+
+export const RosterResponseSchema = t.Object({
+  university: t.Object({
+    title: t.String(),
+    startDate: t.String({ format: "date-time" }),
+    endDate: t.Union([t.String({ format: "date-time" }), t.Null()]),
+    location: t.Object({
+      name: t.String(),
+      address: t.String(),
+      city: t.String(),
+      state: t.String(),
+      zip: t.String(),
+    }),
+    timezone: t.String(),
+  }),
+  classRosters: t.Array(ClassRosterSchema),
+});
+export type RosterResponse = Static<typeof RosterResponseSchema>;

--- a/functions/src/registrations-api/services/registrations/index.ts
+++ b/functions/src/registrations-api/services/registrations/index.ts
@@ -29,7 +29,10 @@ import {
   ForbiddenError,
   NotFoundError,
 } from "../../../shared-api/errors/http-error.js";
-import { assertOwnsScout } from "../../../shared-api/services/authz/assertions.js";
+import {
+  assertChancellorOf,
+  assertOwnsScout,
+} from "../../../shared-api/services/authz/assertions.js";
 import {
   roleGrantsReader,
   type RoleGrantsReader,
@@ -40,8 +43,11 @@ import {
 } from "../../../shared-api/services/authz/scout-ownership-reader.js";
 import type { Caller } from "../../../shared-api/types/caller.js";
 import type {
+  ClassRoster,
   RegisterRequest,
   RegistrationResponse,
+  RosterResponse,
+  RosterRow,
   ScheduleResponse,
 } from "../../schemas/registration-schemas.js";
 import { emailNotifier } from "../notifier/email-notifier.js";
@@ -63,6 +69,20 @@ function toRegistrationResponse(
     badgeTitle: doc.badgeTitle,
     waitlistedAt: toIso(doc.waitlistedAt),
     enrolledAt: toIso(doc.enrolledAt),
+  };
+}
+
+function toRosterRow(doc: RegistrationDocument): RosterRow {
+  return {
+    scoutId: doc.scoutId,
+    scoutFirstName: doc.scoutFirstName,
+    scoutLastName: doc.scoutLastName,
+    scoutUnit: doc.scoutUnit,
+    accommodations: doc.accommodations,
+    parentName: doc.parentName,
+    parentEmail: doc.parentEmail,
+    consentReceived: doc.parentConsentAt != null,
+    status: doc.status as "enrolled" | "waitlisted",
   };
 }
 
@@ -367,6 +387,117 @@ export class RegistrationsServiceImpl implements RegistrationsService {
       toRegistrationResponse(doc.data() as RegistrationDocument),
     );
     return { registrations };
+  }
+
+  async listRoster(
+    caller: Caller,
+    universityId: string,
+  ): Promise<RosterResponse> {
+    const universitySnapshot = await this.db()
+      .collection(UNIVERSITIES_COLLECTION)
+      .doc(universityId)
+      .get();
+    if (!universitySnapshot.exists) {
+      throw new NotFoundError("University not found");
+    }
+    const university = universitySnapshot.data() as UniversityDocument;
+    const periodLabels = new Map(
+      university.periods.map(period => [period.periodId, period.label]),
+    );
+
+    // Chancellors see every class; everyone else is scoped to their active
+    // counselor grants. assertChancellorOf throws (403) on a non-chancellor,
+    // so only that 403 is caught to fall through to the counselor path — any
+    // other error (e.g. a transient Firestore read failure) must surface
+    // rather than silently demote the caller to a narrower view.
+    let classIds: string[] | "all";
+    try {
+      await assertChancellorOf(caller, universityId, this.roleGrants);
+      classIds = "all";
+    } catch (error) {
+      if (!(error instanceof ForbiddenError)) throw error;
+      const granted = await this.roleGrants.listActiveClassGrants({
+        uid: caller.uid,
+        universityId,
+      });
+      if (granted.length === 0) {
+        throw new ForbiddenError(
+          "You do not have access to any classes in this event",
+        );
+      }
+      classIds = granted;
+    }
+
+    const classesSnapshot = await this.db()
+      .collection(classesPath(universityId))
+      .get();
+    const inScopeClasses = classesSnapshot.docs.filter(
+      doc => classIds === "all" || classIds.includes(doc.id),
+    );
+
+    const registrationsSnapshot = await this.db()
+      .collectionGroup(REGISTRATIONS_SUBCOLLECTION)
+      .where("universityId", "==", universityId)
+      .where("status", "in", ["enrolled", "waitlisted"])
+      .get();
+    const rowsByClass = new Map<string, RegistrationDocument[]>();
+    for (const doc of registrationsSnapshot.docs) {
+      const registration = doc.data() as RegistrationDocument;
+      const rows = rowsByClass.get(registration.classId) ?? [];
+      rows.push(registration);
+      rowsByClass.set(registration.classId, rows);
+    }
+
+    const classRosters: ClassRoster[] = inScopeClasses.map(doc => {
+      const classDoc = doc.data() as ClassDocument;
+      const rows = rowsByClass.get(doc.id) ?? [];
+      const enrolled = rows
+        .filter(row => row.status === "enrolled")
+        .sort((a, b) =>
+          a.scoutLastName === b.scoutLastName
+            ? a.scoutFirstName.localeCompare(b.scoutFirstName)
+            : a.scoutLastName.localeCompare(b.scoutLastName),
+        )
+        .map(toRosterRow);
+      const waitlisted = rows
+        .filter(row => row.status === "waitlisted")
+        .sort(
+          (a, b) =>
+            (a.waitlistedAt?.toMillis() ?? 0) -
+            (b.waitlistedAt?.toMillis() ?? 0),
+        )
+        .map(toRosterRow);
+
+      return {
+        class: {
+          classId: doc.id,
+          badgeTitle: classDoc.badgeTitle,
+          periodLabels: classDoc.periodIds.map(
+            id => periodLabels.get(id) ?? id,
+          ),
+          room: classDoc.room,
+          capacity: classDoc.capacity,
+          enrolledCount: classDoc.enrolledCount,
+          waitlistCount: classDoc.waitlistCount,
+          counselorNames: classDoc.counselors.map(
+            counselor => counselor.displayName,
+          ),
+        },
+        enrolled,
+        waitlisted,
+      };
+    });
+
+    return {
+      university: {
+        title: university.title,
+        startDate: university.startDate.toDate().toISOString(),
+        endDate: toIso(university.endDate),
+        location: university.location,
+        timezone: university.timezone,
+      },
+      classRosters,
+    };
   }
 }
 

--- a/functions/src/registrations-api/services/registrations/interface.ts
+++ b/functions/src/registrations-api/services/registrations/interface.ts
@@ -2,6 +2,7 @@ import type { Caller } from "../../../shared-api/types/caller.js";
 import type {
   RegisterRequest,
   RegistrationResponse,
+  RosterResponse,
   ScheduleResponse,
 } from "../../schemas/registration-schemas.js";
 
@@ -20,4 +21,6 @@ export interface RegistrationsService {
   ): Promise<void>;
   /** Stub in Phase 1; a real collection-group query lands in Phase 3. */
   listSchedule(caller: Caller, universityId: string): Promise<ScheduleResponse>;
+  /** Chancellor sees all classes; counselor sees only their active class grants. */
+  listRoster(caller: Caller, universityId: string): Promise<RosterResponse>;
 }

--- a/functions/src/shared-api/services/authz/assertions.test.ts
+++ b/functions/src/shared-api/services/authz/assertions.test.ts
@@ -26,6 +26,7 @@ function readerAllowing(
   return {
     hasActiveGrant: ({ scopeId, role }: GrantQuery) =>
       Promise.resolve(grants.some((g) => g.scopeId === scopeId && g.role === role)),
+    listActiveClassGrants: () => Promise.resolve([]),
   };
 }
 
@@ -45,7 +46,10 @@ describe("assertChancellorOf", () => {
   });
 
   it("allows super-admin without consulting grants", async () => {
-    const reader = { hasActiveGrant: mock(() => Promise.resolve(false)) };
+    const reader = {
+      hasActiveGrant: mock(() => Promise.resolve(false)),
+      listActiveClassGrants: () => Promise.resolve([]),
+    };
     await assertChancellorOf(caller({ superAdmin: true }), "uni1", reader);
     expect(reader.hasActiveGrant).not.toHaveBeenCalled();
   });

--- a/functions/src/shared-api/services/authz/role-grants-reader.ts
+++ b/functions/src/shared-api/services/authz/role-grants-reader.ts
@@ -1,6 +1,7 @@
 import { getFirestore } from "firebase-admin/firestore";
 import {
   type GrantRole,
+  type RoleGrantDocument,
   ROLE_GRANTS_COLLECTION,
 } from "../../../collections/role-grants.js";
 
@@ -17,6 +18,11 @@ export interface GrantQuery {
  */
 export interface RoleGrantsReader {
   hasActiveGrant(query: GrantQuery): Promise<boolean>;
+  /** Active class-scoped counselor grants for a user within one university. */
+  listActiveClassGrants(query: {
+    uid: string;
+    universityId: string;
+  }): Promise<string[]>;
 }
 
 /**
@@ -35,5 +41,19 @@ export const roleGrantsReader: RoleGrantsReader = {
       .limit(1)
       .get();
     return !snapshot.empty;
+  },
+
+  async listActiveClassGrants({ uid, universityId }) {
+    const snapshot = await getFirestore()
+      .collection(ROLE_GRANTS_COLLECTION)
+      .where("uid", "==", uid)
+      .where("role", "==", "counselor")
+      .where("scopeType", "==", "class")
+      .where("status", "==", "active")
+      .get();
+    return snapshot.docs
+      .map(doc => doc.data() as RoleGrantDocument)
+      .filter(grant => grant.universityId === universityId)
+      .map(grant => grant.scopeId);
   },
 };


### PR DESCRIPTION
Closes #86.

## What

Adds the Phase 1 roster feature: chancellors and counselors can view, print, and CSV-export class rosters for an event.

### Backend (`registrations-api`)
- **New endpoint** `GET /api/registrations/:universityId/roster` (the only new route). Behind the existing `requireAuth`.
- **Authz:** resolve the caller's effective class set — chancellor grant ⇒ all classes; else the classes where they hold an active `counselor` grant. Empty set ⇒ **403**. Chancellor of a zero-class event ⇒ **200 + empty array**. Only a `ForbiddenError` falls through the chancellor check to the counselor path; other errors surface.
- **Assembly:** read-time, in memory — university doc (header + period labels) + classes subcollection + one collection-group `registrations` query scoped by `universityId` (status `in [enrolled, waitlisted]`). No materialized roster doc.
- **Response (wrapped):** `{ university, classRosters: [{ class, enrolled[], waitlisted[] }] }`. Enrolled sorted by last/first name; waitlisted by `waitlistedAt asc` (position derived). Cancelled excluded; empty classes still appear.
- New `(universityId, status)` COLLECTION_GROUP index; new `listActiveClassGrants` reader (reuses the existing `(uid, role, scopeType, status)` index).

### Frontend
- `RosterPage` at `/universities/:id/roster` (auth→verified→onboarded), reached via a **View rosters** link on the university editor.
- Signal-driven roster `httpResource` in the `Registrations` service. 403 → dashboard redirect + flash (existing pattern).
- **Print:** `@media print` + `window.print()`, page-break between classes, app chrome/buttons hidden.
- **CSV:** pure `lib/roster-csv.ts` util (RFC-4180 escaping), per-class and whole-event exports. `Present` is an empty attendance column on enrolled rows (no persistence).
- Adds the missing `/api/registrations` dev proxy entry.

## Testing

Per the project testing layers: unit tests (mocked services backend / functional UI) + Playwright e2e (Auth-emulator login, mocked `/api`). Firestore/index/transaction correctness stays in the manual smoke scripts.

- Backend route tests (200 incl. empty class, 403 no-access, 404 missing university) — service mocked at the boundary.
- CSV util unit tests (RFC-4180 escaping, waitlist numbering, event vs class columns).
- `RosterPage` functional test (renders tables incl. empty class; 403 → flash + redirect).
- Playwright roster e2e (render + 403 redirect).

`bun test` (functions, 81) and `ng test` (app, 45) green; `tsc --noEmit` clean.