### PR TITLE
Add moderation v1: event status state machine + super-admin review queue — issue #87

### DIFF
--- a/app/proxy.conf.json
+++ b/app/proxy.conf.json
@@ -14,6 +14,11 @@
     "secure": false,
     "changeOrigin": true
   },
+  "/api/admin/universities": {
+    "target": "http://localhost:5001/merit-badge-university/us-east4/universitiesApi",
+    "secure": false,
+    "changeOrigin": true
+  },
   "/api/registrations": {
     "target": "http://localhost:5001/merit-badge-university/us-east4/registrationsApi",
     "secure": false,

--- a/app/src/app/admin/review-detail/review-detail.css
+++ b/app/src/app/admin/review-detail/review-detail.css
@@ -1,0 +1,49 @@
+.review-detail {
+  max-width: 40rem;
+  margin: 2rem auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 0 1rem;
+}
+
+.review-detail__header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.review-detail__meta {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.25rem 1rem;
+  margin: 0;
+}
+
+.review-detail__meta dt {
+  color: var(--color-muted);
+}
+
+.review-detail__classes ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.review-detail__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.review-detail__reject-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.review-detail__error {
+  color: var(--color-error);
+}

--- a/app/src/app/admin/review-detail/review-detail.html
+++ b/app/src/app/admin/review-detail/review-detail.html
@@ -1,0 +1,63 @@
+<main class="review-detail">
+  <a routerLink="/admin/review">← Back to queue</a>
+
+  @if (detail.isLoading()) {
+    <p>Loading…</p>
+  } @else if (detail.error()) {
+    <p class="review-detail__error" role="alert">Could not load this university.</p>
+  } @else if (detail.value(); as data) {
+    <header class="review-detail__header">
+      <h1>{{ data.university.title }}</h1>
+      <app-status-badge [status]="data.university.status" />
+    </header>
+
+    <dl class="review-detail__meta">
+      <dt>Location</dt>
+      <dd>
+        {{ data.university.location.name }}, {{ data.university.location.city }},
+        {{ data.university.location.state }}
+      </dd>
+      <dt>Timezone</dt>
+      <dd>{{ data.university.timezone }}</dd>
+      <dt>Classes</dt>
+      <dd>{{ data.classes.length }}</dd>
+    </dl>
+
+    <section class="review-detail__classes">
+      <h2>Classes</h2>
+      <ul>
+        @for (cls of data.classes; track cls.classId) {
+          <li>{{ cls.badgeTitle }} · cap {{ cls.capacity }}</li>
+        }
+      </ul>
+    </section>
+
+    @if (actionError(); as message) {
+      <p class="review-detail__error" role="alert">{{ message }}</p>
+    }
+
+    @if (data.university.status === 'submitted') {
+      <div class="review-detail__actions">
+        <button type="button" [disabled]="actionPending()" (click)="approve()">Approve</button>
+        @if (!showRejectForm()) {
+          <button type="button" (click)="showRejectForm.set(true)">Reject</button>
+        }
+      </div>
+
+      @if (showRejectForm()) {
+        <form class="review-detail__reject-form" (ngSubmit)="reject()">
+          <label for="rejectNote">Reason for rejection</label>
+          <textarea
+            id="rejectNote"
+            [value]="rejectNote()"
+            (input)="setRejectNote($any($event.target).value)"
+            required
+          ></textarea>
+          <button type="submit" [disabled]="actionPending() || !rejectNote().trim()">
+            Submit rejection
+          </button>
+        </form>
+      }
+    }
+  }
+</main>

--- a/app/src/app/admin/review-detail/review-detail.spec.ts
+++ b/app/src/app/admin/review-detail/review-detail.spec.ts
@@ -1,0 +1,144 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router, RouterOutlet } from '@angular/router';
+import { render, screen } from '@testing-library/angular/zoneless';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { Universities } from '../../services/universities';
+import { fakeResource } from '../../test-utils/fake-resource';
+import { ReviewDetail } from './review-detail';
+
+@Component({ template: '<router-outlet />', imports: [RouterOutlet] })
+class TestApp {}
+
+@Component({ template: '<p>Queue</p>' })
+class QueueStub {}
+
+describe('ReviewDetail', () => {
+  interface SetupOptions {
+    status?: string;
+    approveFails?: boolean;
+    rejectFails?: boolean;
+  }
+
+  async function setup({
+    status = 'submitted',
+    approveFails = false,
+    rejectFails = false,
+  }: SetupOptions = {}) {
+    const detail = fakeResource({
+      university: {
+        id: 'uni1',
+        title: 'Spring MBU',
+        status,
+        timezone: 'America/New_York',
+        startDate: '2026-06-01T12:00:00.000Z',
+        endDate: null,
+        registrationOpensAt: null,
+        registrationClosesAt: '2026-05-25T23:59:59.000Z',
+        location: {
+          name: 'Scout Hall',
+          address: '1 Main St',
+          city: 'Anytown',
+          state: 'NY',
+          zip: '12345',
+        },
+        periods: [],
+        createdByUid: 'u1',
+        reviewNote: null,
+        submittedAt: '2026-07-01T00:00:00.000Z',
+        createdAt: '2026-07-01T00:00:00.000Z',
+        updatedAt: '2026-07-01T00:00:00.000Z',
+      },
+      classes: [
+        {
+          classId: 'cls1',
+          badgeSlug: 'camping',
+          badgeTitle: 'Camping',
+          eagleRequired: true,
+          periodIds: [],
+          capacity: 20,
+          enrolledCount: 0,
+          waitlistCount: 0,
+          room: null,
+          notes: null,
+          counselors: [],
+          createdAt: '2026-07-01T00:00:00.000Z',
+          updatedAt: '2026-07-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    await render(TestApp, {
+      providers: [
+        provideRouter([
+          { path: 'admin/review', component: QueueStub },
+          { path: 'admin/review/:id', component: ReviewDetail },
+        ]),
+        {
+          provide: Universities,
+          useValue: {
+            detail,
+            openUniversity: vi.fn(),
+            approveUniversity: vi.fn(() =>
+              approveFails ? Promise.reject(new Error('fail')) : Promise.resolve(),
+            ),
+            rejectUniversity: vi.fn(() =>
+              rejectFails ? Promise.reject(new Error('fail')) : Promise.resolve(),
+            ),
+            apiErrorMessage: (_error: unknown, fallback: string) => fallback,
+          },
+        },
+      ],
+    });
+    await TestBed.inject(Router).navigateByUrl('/admin/review/uni1');
+    await screen.findByText('Spring MBU');
+
+    return { user: userEvent.setup() };
+  }
+
+  it('renders the event and its classes for a submitted event', async () => {
+    await setup();
+
+    expect(screen.getByText('submitted')).toBeVisible();
+    expect(screen.getByText(/Camping/)).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Approve' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Reject' })).toBeVisible();
+  });
+
+  it('approves and navigates back to the queue', async () => {
+    const { user } = await setup();
+
+    await user.click(screen.getByRole('button', { name: 'Approve' }));
+
+    expect(await screen.findByText('Queue')).toBeVisible();
+  });
+
+  it('shows an error and stays on the page when approval fails', async () => {
+    const { user } = await setup({ approveFails: true });
+
+    await user.click(screen.getByRole('button', { name: 'Approve' }));
+
+    expect(await screen.findByText('Could not approve this event.')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Approve' })).toBeVisible();
+  });
+
+  it('rejects with a note and navigates back to the queue', async () => {
+    const { user } = await setup();
+
+    await user.click(screen.getByRole('button', { name: 'Reject' }));
+    const textarea = await screen.findByLabelText('Reason for rejection');
+    await user.type(textarea, 'Missing counselor disclaimers');
+    await user.click(screen.getByRole('button', { name: 'Submit rejection' }));
+
+    expect(await screen.findByText('Queue')).toBeVisible();
+  });
+
+  it('disables the rejection submit button until a note is entered', async () => {
+    const { user } = await setup();
+
+    await user.click(screen.getByRole('button', { name: 'Reject' }));
+
+    expect(screen.getByRole('button', { name: 'Submit rejection' })).toBeDisabled();
+  });
+});

--- a/app/src/app/admin/review-detail/review-detail.ts
+++ b/app/src/app/admin/review-detail/review-detail.ts
@@ -1,0 +1,78 @@
+import { ChangeDetectionStrategy, Component, effect, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { StatusBadge } from '../../shared/status-badge/status-badge';
+import { Universities } from '../../services/universities';
+
+@Component({
+  selector: 'app-review-detail',
+  imports: [RouterLink, StatusBadge, FormsModule],
+  templateUrl: './review-detail.html',
+  styleUrl: './review-detail.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ReviewDetail {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  protected readonly universities = inject(Universities);
+
+  protected readonly universityId = signal<string>('');
+
+  /** Reactive route param — re-fires when navigating :idA → :idB (component reused). */
+  private readonly routeParams = toSignal(this.route.paramMap);
+
+  protected readonly detail = this.universities.detail;
+
+  protected readonly showRejectForm = signal(false);
+  protected readonly rejectNote = signal('');
+  protected readonly actionPending = signal(false);
+  protected readonly actionError = signal('');
+
+  constructor() {
+    effect(() => {
+      const id = this.routeParams()?.get('id');
+      if (id) {
+        this.universityId.set(id);
+        this.universities.openUniversity(id);
+      }
+    });
+  }
+
+  protected setRejectNote(value: string): void {
+    this.rejectNote.set(value);
+  }
+
+  protected async approve(): Promise<void> {
+    this.actionError.set('');
+    this.actionPending.set(true);
+    try {
+      await this.universities.approveUniversity(this.universityId());
+      await this.router.navigate(['/admin/review']);
+    } catch (error) {
+      this.actionError.set(
+        this.universities.apiErrorMessage(error, 'Could not approve this event.'),
+      );
+    } finally {
+      this.actionPending.set(false);
+    }
+  }
+
+  protected async reject(): Promise<void> {
+    const note = this.rejectNote().trim();
+    if (!note) return;
+
+    this.actionError.set('');
+    this.actionPending.set(true);
+    try {
+      await this.universities.rejectUniversity(this.universityId(), note);
+      await this.router.navigate(['/admin/review']);
+    } catch (error) {
+      this.actionError.set(
+        this.universities.apiErrorMessage(error, 'Could not reject this event.'),
+      );
+    } finally {
+      this.actionPending.set(false);
+    }
+  }
+}

--- a/app/src/app/admin/review-queue/review-queue.css
+++ b/app/src/app/admin/review-queue/review-queue.css
@@ -1,0 +1,46 @@
+.review-queue {
+  max-width: 40rem;
+  margin: 2rem auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0 1rem;
+}
+
+.review-queue__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.review-queue__card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  text-decoration: none;
+  color: inherit;
+  background: var(--color-surface);
+}
+
+.review-queue__title {
+  font-weight: 600;
+}
+
+.review-queue__meta {
+  font-size: 0.875rem;
+  color: var(--color-muted);
+}
+
+.review-queue__error {
+  color: var(--color-error);
+}
+
+.review-queue__empty {
+  color: var(--color-muted);
+}

--- a/app/src/app/admin/review-queue/review-queue.html
+++ b/app/src/app/admin/review-queue/review-queue.html
@@ -1,0 +1,31 @@
+<main class="review-queue">
+  <header class="review-queue__header">
+    <h1>Review Queue</h1>
+  </header>
+
+  @if (queue.error()) {
+    <p class="review-queue__error" role="alert">Could not load the review queue.</p>
+  } @else if (queue.isLoading()) {
+    <p>Loading…</p>
+  } @else if (isEmpty()) {
+    <p class="review-queue__empty">Nothing is waiting for review.</p>
+  } @else {
+    <ul class="review-queue__list">
+      @for (row of rows(); track row.id) {
+        <li>
+          <a [routerLink]="['/admin/review', row.id]" class="review-queue__card">
+            <span class="review-queue__title">{{ row.title }}</span>
+            <span class="review-queue__meta">
+              {{ row.chancellorName }} ({{ row.chancellorEmail }}) ·
+              {{ row.startDate | date: 'mediumDate' }} · {{ row.classCount }}
+              {{ row.classCount === 1 ? 'class' : 'classes' }}
+              @if (row.submittedAt) {
+                · submitted {{ row.submittedAt | date: 'medium' }}
+              }
+            </span>
+          </a>
+        </li>
+      }
+    </ul>
+  }
+</main>

--- a/app/src/app/admin/review-queue/review-queue.spec.ts
+++ b/app/src/app/admin/review-queue/review-queue.spec.ts
@@ -1,0 +1,55 @@
+import { provideRouter } from '@angular/router';
+import { render, screen } from '@testing-library/angular/zoneless';
+import { describe, expect, it } from 'vitest';
+import type { ReviewQueueRow } from '../../api-types/universities-api.types';
+import { Universities } from '../../services/universities';
+import { fakeResource } from '../../test-utils/fake-resource';
+import { ReviewQueue } from './review-queue';
+
+describe('ReviewQueue', () => {
+  interface SetupOptions {
+    rows?: ReviewQueueRow[];
+  }
+
+  const sampleRow: ReviewQueueRow = {
+    id: 'uni1',
+    title: 'Spring MBU',
+    chancellorName: 'Alex Chancellor',
+    chancellorEmail: 'alex@example.com',
+    submittedAt: '2026-07-01T00:00:00.000Z',
+    classCount: 2,
+    startDate: '2026-06-01T12:00:00.000Z',
+  };
+
+  async function setup({ rows = [sampleRow] }: SetupOptions = {}) {
+    await render(ReviewQueue, {
+      providers: [
+        provideRouter([]),
+        {
+          provide: Universities,
+          useValue: {
+            reviewQueue: fakeResource({ universities: rows }),
+            openReviewQueue: () => {},
+          },
+        },
+      ],
+    });
+  }
+
+  it('renders a row per queued university', async () => {
+    await setup();
+
+    expect(await screen.findByText('Spring MBU')).toBeVisible();
+    expect(screen.getByText(/Alex Chancellor/)).toBeVisible();
+    expect(screen.getByRole('link', { name: /Spring MBU/ })).toHaveAttribute(
+      'href',
+      '/admin/review/uni1',
+    );
+  });
+
+  it('shows an empty state when nothing is queued', async () => {
+    await setup({ rows: [] });
+
+    expect(await screen.findByText('Nothing is waiting for review.')).toBeVisible();
+  });
+});

--- a/app/src/app/admin/review-queue/review-queue.ts
+++ b/app/src/app/admin/review-queue/review-queue.ts
@@ -1,0 +1,23 @@
+import { DatePipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { Universities } from '../../services/universities';
+
+@Component({
+  selector: 'app-review-queue',
+  imports: [RouterLink, DatePipe],
+  templateUrl: './review-queue.html',
+  styleUrl: './review-queue.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ReviewQueue {
+  protected readonly universities = inject(Universities);
+
+  protected readonly queue = this.universities.reviewQueue;
+  protected readonly rows = computed(() => this.queue.value()?.universities ?? []);
+  protected readonly isEmpty = computed(() => this.rows().length === 0);
+
+  constructor() {
+    this.universities.openReviewQueue();
+  }
+}

--- a/app/src/app/api-types/universities-api.types.ts
+++ b/app/src/app/api-types/universities-api.types.ts
@@ -7,12 +7,7 @@ export interface UniversityLocation {
 }
 
 export type UniversityStatus =
-  | 'draft'
-  | 'submitted'
-  | 'needs_review'
-  | 'published'
-  | 'closed'
-  | 'rejected';
+  'draft' | 'submitted' | 'needs_review' | 'published' | 'closed' | 'rejected';
 
 export interface UniversityResponse {
   id: string;
@@ -25,6 +20,8 @@ export interface UniversityResponse {
   registrationClosesAt: string;
   location: UniversityLocation;
   createdByUid: string;
+  reviewNote: string | null;
+  submittedAt: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -174,6 +171,20 @@ export interface PublicUniversity {
   location: UniversityLocation;
   periods: Period[];
   classes: PublicClass[];
+}
+
+export interface ReviewQueueRow {
+  id: string;
+  title: string;
+  chancellorName: string;
+  chancellorEmail: string;
+  submittedAt: string | null;
+  classCount: number;
+  startDate: string;
+}
+
+export interface ReviewQueueResponse {
+  universities: ReviewQueueRow[];
 }
 
 export interface ApiErrorBody {

--- a/app/src/app/app.routes.ts
+++ b/app/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { type Routes } from '@angular/router';
 import {
   requireAuth,
   requireOnboarded,
+  requireSuperAdmin,
   requireUnauth,
   requireVerified,
 } from './guards/auth-guards';
@@ -9,8 +10,7 @@ import {
 export const routes: Routes = [
   {
     path: 'e/:id',
-    loadComponent: () =>
-      import('./public-event/public-event').then((m) => m.PublicEvent),
+    loadComponent: () => import('./public-event/public-event').then((m) => m.PublicEvent),
   },
   {
     path: 'e/:id/register',
@@ -25,14 +25,12 @@ export const routes: Routes = [
   {
     path: 'verify-email',
     canActivate: [requireAuth],
-    loadComponent: () =>
-      import('./verify-email/verify-email').then((m) => m.VerifyEmail),
+    loadComponent: () => import('./verify-email/verify-email').then((m) => m.VerifyEmail),
   },
   {
     path: 'onboarding',
     canActivate: [requireAuth, requireVerified],
-    loadComponent: () =>
-      import('./onboarding/onboarding').then((m) => m.Onboarding),
+    loadComponent: () => import('./onboarding/onboarding').then((m) => m.Onboarding),
   },
   {
     path: 'universities',
@@ -48,9 +46,7 @@ export const routes: Routes = [
       {
         path: 'new',
         loadComponent: () =>
-          import('./universities/university-new/university-new').then(
-            (m) => m.UniversityNew,
-          ),
+          import('./universities/university-new/university-new').then((m) => m.UniversityNew),
       },
       {
         path: ':id',
@@ -63,6 +59,21 @@ export const routes: Routes = [
         path: ':id/roster',
         loadComponent: () =>
           import('./universities/roster-page/roster-page').then((m) => m.RosterPage),
+      },
+    ],
+  },
+  {
+    path: 'admin',
+    canActivate: [requireAuth, requireVerified, requireOnboarded, requireSuperAdmin],
+    children: [
+      {
+        path: 'review',
+        loadComponent: () => import('./admin/review-queue/review-queue').then((m) => m.ReviewQueue),
+      },
+      {
+        path: 'review/:id',
+        loadComponent: () =>
+          import('./admin/review-detail/review-detail').then((m) => m.ReviewDetail),
       },
     ],
   },

--- a/app/src/app/guards/auth-guards.spec.ts
+++ b/app/src/app/guards/auth-guards.spec.ts
@@ -1,11 +1,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import {
-  Router,
-  RouterOutlet,
-  provideRouter,
-  type Routes,
-} from '@angular/router';
+import { Router, RouterOutlet, provideRouter, type Routes } from '@angular/router';
 import { render, screen } from '@testing-library/angular/zoneless';
 import { describe, expect, it, vi } from 'vitest';
 import type { BootstrapResponse } from '../api-types/users-api.types';
@@ -13,6 +8,7 @@ import { Auth } from '../services/auth';
 import {
   requireAuth,
   requireOnboarded,
+  requireSuperAdmin,
   requireUnauth,
   requireVerified,
 } from './auth-guards';
@@ -21,10 +17,7 @@ import {
 // mock at the firebase SDK boundary instead.
 const { mockAuth } = vi.hoisted(() => ({
   mockAuth: {
-    currentUser: undefined as
-      | { uid: string; emailVerified: boolean }
-      | null
-      | undefined,
+    currentUser: undefined as { uid: string; emailVerified: boolean } | null | undefined,
     authStateReady: vi.fn<() => Promise<void>>(() => Promise.resolve()),
   },
 }));
@@ -39,15 +32,35 @@ vi.mock('firebase/firestore', () => ({
   connectFirestoreEmulator: vi.fn(),
 }));
 
-@Component({ selector: 'app-mock-home', template: '<h1>Home</h1>', changeDetection: ChangeDetectionStrategy.OnPush })
+@Component({
+  selector: 'app-mock-home',
+  template: '<h1>Home</h1>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
 class MockHome {}
-@Component({ selector: 'app-mock-sign-in', template: '<h1>Sign In</h1>', changeDetection: ChangeDetectionStrategy.OnPush })
+@Component({
+  selector: 'app-mock-sign-in',
+  template: '<h1>Sign In</h1>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
 class MockSignIn {}
-@Component({ selector: 'app-mock-verify', template: '<h1>Verify</h1>', changeDetection: ChangeDetectionStrategy.OnPush })
+@Component({
+  selector: 'app-mock-verify',
+  template: '<h1>Verify</h1>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
 class MockVerify {}
-@Component({ selector: 'app-mock-onboarding', template: '<h1>Onboarding</h1>', changeDetection: ChangeDetectionStrategy.OnPush })
+@Component({
+  selector: 'app-mock-onboarding',
+  template: '<h1>Onboarding</h1>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
 class MockOnboarding {}
-@Component({ selector: 'app-mock-protected', template: '<h1>Protected</h1>', changeDetection: ChangeDetectionStrategy.OnPush })
+@Component({
+  selector: 'app-mock-protected',
+  template: '<h1>Protected</h1>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
 class MockProtected {}
 @Component({
   template: '<router-outlet></router-outlet>',
@@ -66,6 +79,7 @@ const routes: Routes = [
   { path: 'guest-only', component: MockSignIn, canActivate: [requireUnauth] },
   { path: 'return-target', component: MockProtected },
   { path: 'onboarded-only', component: MockProtected, canActivate: [requireOnboarded] },
+  { path: 'admin-only', component: MockProtected, canActivate: [requireSuperAdmin] },
 ];
 
 describe('auth route guards', () => {
@@ -144,6 +158,20 @@ describe('auth route guards', () => {
       expect(screen.getByText('Protected')).toBeVisible();
     });
   });
+
+  describe('requireSuperAdmin', () => {
+    it('redirects a non-super-admin to the app home', async () => {
+      const { navigate } = await setup({ superAdmin: false });
+      await navigate('/admin-only');
+      expect(screen.getByText('Home')).toBeVisible();
+    });
+
+    it('allows a super-admin through', async () => {
+      const { navigate } = await setup({ superAdmin: true });
+      await navigate('/admin-only');
+      expect(screen.getByText('Protected')).toBeVisible();
+    });
+  });
 });
 
 function fakeUser() {
@@ -160,22 +188,21 @@ function fakeUser() {
 interface SetupOptions {
   currentUser?: { uid: string; emailVerified: boolean } | null;
   bootstrap?: BootstrapResponse | undefined;
+  superAdmin?: boolean;
 }
 
-async function setup({ currentUser, bootstrap }: SetupOptions = {}) {
+async function setup({ currentUser, bootstrap, superAdmin = false }: SetupOptions = {}) {
   vi.spyOn(console, 'error').mockReturnValue(undefined);
   mockAuth.currentUser = currentUser;
   mockAuth.authStateReady = vi.fn(() => Promise.resolve());
 
   const mockAuthService = {
     ensureBootstrap: vi.fn(() => Promise.resolve(bootstrap)),
+    ensureSuperAdmin: vi.fn(() => Promise.resolve(superAdmin)),
   };
 
   await render(MockApp, {
-    providers: [
-      provideRouter(routes),
-      { provide: Auth, useValue: mockAuthService },
-    ],
+    providers: [provideRouter(routes), { provide: Auth, useValue: mockAuthService }],
   });
 
   const router = TestBed.inject(Router);

--- a/app/src/app/guards/auth-guards.ts
+++ b/app/src/app/guards/auth-guards.ts
@@ -35,6 +35,13 @@ export const requireOnboarded: CanActivateFn = async () => {
   return bootstrap?.needsConsent ? router.parseUrl('/onboarding') : true;
 };
 
+/** Requires the super-admin custom claim. Redirects to / otherwise. */
+export const requireSuperAdmin: CanActivateFn = async () => {
+  const router = inject(Router);
+  const authService = inject(Auth);
+  return (await authService.ensureSuperAdmin()) ? true : router.parseUrl('/');
+};
+
 /** Inverse of requireAuth: sends already signed-in users to the app home. */
 export const requireUnauth: CanActivateFn = async (route) => {
   const router = inject(Router);

--- a/app/src/app/services/auth.ts
+++ b/app/src/app/services/auth.ts
@@ -1,12 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import {
-  computed,
-  effect,
-  inject,
-  resource,
-  Service,
-  signal,
-} from '@angular/core';
+import { computed, effect, inject, resource, Service, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import {
   createUserWithEmailAndPassword,
@@ -34,12 +27,9 @@ export const AUTH_ERROR_MESSAGES: Record<string, string> = {
   'auth/wrong-password': 'Incorrect password.',
   'auth/invalid-credential': 'Invalid email or password.',
   'auth/popup-closed-by-user': 'Sign-in was cancelled.',
-  'auth/too-many-requests':
-    'Too many failed attempts. Please try again later.',
-  'auth/network-request-failed':
-    'Network error. Please check your connection and try again.',
-  'auth/unknown-error':
-    'An error occurred during authentication. Please try again.',
+  'auth/too-many-requests': 'Too many failed attempts. Please try again later.',
+  'auth/network-request-failed': 'Network error. Please check your connection and try again.',
+  'auth/unknown-error': 'An error occurred during authentication. Please try again.',
 };
 
 @Service()
@@ -50,9 +40,7 @@ export class Auth {
   private readonly authUser = signal<User | null>(null);
 
   readonly user = this.authUser.asReadonly();
-  readonly emailVerified = computed(
-    () => this.authUser()?.emailVerified ?? false,
-  );
+  readonly emailVerified = computed(() => this.authUser()?.emailVerified ?? false);
 
   // superAdmin custom claim, resolved from the ID token. Fails closed to false:
   // an undefined value covers both "loading" and "claim fetch failed".
@@ -70,15 +58,11 @@ export class Auth {
   // has a verified email (the API rejects unverified sessions with 403).
   readonly session = resource({
     params: () =>
-      this.authUser() && this.emailVerified()
-        ? { uid: this.authUser()?.uid }
-        : undefined,
+      this.authUser() && this.emailVerified() ? { uid: this.authUser()?.uid } : undefined,
     loader: () => this.postBootstrap(),
   });
 
-  readonly needsConsent = computed(
-    () => this.session.value()?.needsConsent ?? false,
-  );
+  readonly needsConsent = computed(() => this.session.value()?.needsConsent ?? false);
   readonly sessionUser = computed(() => this.session.value()?.user);
 
   constructor() {
@@ -109,9 +93,7 @@ export class Auth {
   }
 
   private async postBootstrap(): Promise<BootstrapResponse> {
-    return await firstValueFrom(
-      this.httpClient.post<BootstrapResponse>('/api/users/me', {}),
-    );
+    return await firstValueFrom(this.httpClient.post<BootstrapResponse>('/api/users/me', {}));
   }
 
   /**
@@ -124,6 +106,19 @@ export class Auth {
     return await this.postBootstrap();
   }
 
+  /**
+   * Resolves the superAdmin custom claim directly from the ID token, for use
+   * in route guards. The `superAdmin` signal above fails closed to `false`
+   * while its claim resource loads, so a guard reading it synchronously would
+   * incorrectly reject a super-admin whose claim hasn't resolved yet.
+   */
+  async ensureSuperAdmin(): Promise<boolean> {
+    const user = auth.currentUser;
+    if (!user) return false;
+    const result = await getIdTokenResult(user);
+    return result.claims['superAdmin'] === true;
+  }
+
   async signInWithGoogle(): Promise<UserCredential> {
     try {
       return await signInWithPopup(auth, new GoogleAuthProvider());
@@ -132,10 +127,7 @@ export class Auth {
     }
   }
 
-  async signInWithEmailPassword(
-    email: string,
-    password: string,
-  ): Promise<UserCredential> {
+  async signInWithEmailPassword(email: string, password: string): Promise<UserCredential> {
     try {
       return await signInWithEmailAndPassword(auth, email, password);
     } catch (error) {
@@ -143,16 +135,9 @@ export class Auth {
     }
   }
 
-  async signUpWithEmailPassword(
-    email: string,
-    password: string,
-  ): Promise<UserCredential> {
+  async signUpWithEmailPassword(email: string, password: string): Promise<UserCredential> {
     try {
-      const credential = await createUserWithEmailAndPassword(
-        auth,
-        email,
-        password,
-      );
+      const credential = await createUserWithEmailAndPassword(auth, email, password);
       await sendEmailVerification(credential.user, {
         url: `${globalThis.location.origin}/onboarding`,
       });
@@ -218,9 +203,6 @@ export class Auth {
       error: error instanceof Error ? error.message : String(error),
       ...context,
     });
-    return new Error(
-      AUTH_ERROR_MESSAGES[errorCode] ??
-        AUTH_ERROR_MESSAGES['auth/unknown-error'],
-    );
+    return new Error(AUTH_ERROR_MESSAGES[errorCode] ?? AUTH_ERROR_MESSAGES['auth/unknown-error']);
   }
 }

--- a/app/src/app/services/universities.ts
+++ b/app/src/app/services/universities.ts
@@ -10,6 +10,7 @@ import type {
   PeriodsPutRequest,
   PeriodsResponse,
   PublicUniversity,
+  ReviewQueueResponse,
   UniversityCreateRequest,
   UniversityDetailResponse,
   UniversityListResponse,
@@ -47,6 +48,23 @@ export class Universities {
     const id = this.activePublicUniversityId();
     return id ? `/api/universities/${id}/public` : undefined;
   });
+
+  /** Set by the admin review-queue route; gates the super-admin-only queue fetch. */
+  readonly activeReviewQueue = signal(false);
+
+  readonly reviewQueue = httpResource<ReviewQueueResponse>(() =>
+    this.activeReviewQueue() ? '/api/admin/universities/review-queue' : undefined,
+  );
+
+  openReviewQueue(): void {
+    // Gate the admin-only fetch behind explicit activation so it never fires
+    // (and 403s) for non-super-admins who inject this service on other pages.
+    if (this.activeReviewQueue()) {
+      this.reviewQueue.reload();
+    } else {
+      this.activeReviewQueue.set(true);
+    }
+  }
 
   openUniversity(id: string): void {
     // Changing the id makes the detail resource refetch on its own; only force a
@@ -153,6 +171,52 @@ export class Universities {
     await firstValueFrom(this.httpClient.delete(`/api/universities/${id}`));
     this.clearActiveUniversity();
     this.reloadMine();
+  }
+
+  async submitUniversity(id: string): Promise<UniversityResponse> {
+    const result = await firstValueFrom(
+      this.httpClient.post<UniversityResponse>(`/api/universities/${id}/submit`, {}),
+    );
+    this.reloadMine();
+    if (this.activeUniversityId() === id) {
+      this.reloadDetail();
+    }
+    return result;
+  }
+
+  async closeUniversity(id: string): Promise<UniversityResponse> {
+    const result = await firstValueFrom(
+      this.httpClient.post<UniversityResponse>(`/api/universities/${id}/close`, {}),
+    );
+    this.reloadMine();
+    if (this.activeUniversityId() === id) {
+      this.reloadDetail();
+    }
+    return result;
+  }
+
+  async approveUniversity(id: string): Promise<UniversityResponse> {
+    const result = await firstValueFrom(
+      this.httpClient.post<UniversityResponse>(`/api/admin/universities/${id}/approve`, {}),
+    );
+    this.reviewQueue.reload();
+    if (this.activeUniversityId() === id) {
+      this.reloadDetail();
+    }
+    return result;
+  }
+
+  async rejectUniversity(id: string, note: string): Promise<UniversityResponse> {
+    const result = await firstValueFrom(
+      this.httpClient.post<UniversityResponse>(`/api/admin/universities/${id}/reject`, {
+        note,
+      }),
+    );
+    this.reviewQueue.reload();
+    if (this.activeUniversityId() === id) {
+      this.reloadDetail();
+    }
+    return result;
   }
 
   isForbidden(error: unknown): boolean {

--- a/app/src/app/shared/status-badge/status-badge.css
+++ b/app/src/app/shared/status-badge/status-badge.css
@@ -1,0 +1,37 @@
+.status-badge {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  background: var(--color-surface);
+  color: var(--color-muted);
+  border: 1px solid var(--color-border);
+}
+
+.status-badge--submitted,
+.status-badge--needs_review {
+  color: #8a6d00;
+  border-color: #e0c14b;
+  background: #fdf6e0;
+}
+
+.status-badge--published {
+  color: #1a7a3f;
+  border-color: #7fcf9e;
+  background: #e6f7ec;
+}
+
+.status-badge--rejected {
+  color: var(--color-error);
+  border-color: var(--color-error);
+  background: #fbe9e9;
+}
+
+.status-badge--closed {
+  color: var(--color-muted);
+  border-color: var(--color-border);
+  background: var(--color-surface);
+}

--- a/app/src/app/shared/status-badge/status-badge.html
+++ b/app/src/app/shared/status-badge/status-badge.html
@@ -1,0 +1,1 @@
+<span class="status-badge" [class]="'status-badge--' + status()">{{ status() }}</span>

--- a/app/src/app/shared/status-badge/status-badge.ts
+++ b/app/src/app/shared/status-badge/status-badge.ts
@@ -1,0 +1,12 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+/** Accepts a plain string since list summaries carry an unliteraled status from the API. */
+@Component({
+  selector: 'app-status-badge',
+  templateUrl: './status-badge.html',
+  styleUrl: './status-badge.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class StatusBadge {
+  readonly status = input.required<string>();
+}

--- a/app/src/app/test-utils/fake-resource.ts
+++ b/app/src/app/test-utils/fake-resource.ts
@@ -1,0 +1,31 @@
+import { signal } from '@angular/core';
+
+/**
+ * Minimal stand-in for Angular's `httpResource`, backed by writable signals so
+ * a component's `computed()`/`effect()` react to it the same way they would to
+ * the real resource. Use this to mock service-level resources in component
+ * tests instead of reaching for `HttpTestingController` — the service is the
+ * boundary under test, not the transport it happens to use internally.
+ */
+export function fakeResource<T>(initial?: T) {
+  const valueSignal = signal<T | undefined>(initial);
+  const errorSignal = signal<unknown>(undefined);
+  const isLoadingSignal = signal(false);
+
+  return {
+    value: valueSignal.asReadonly(),
+    error: errorSignal.asReadonly(),
+    isLoading: isLoadingSignal.asReadonly(),
+    reload: (): void => {
+      /* no-op in tests; call `set`/`setError` to change what the resource reports */
+    },
+    set(next: T): void {
+      errorSignal.set(undefined);
+      valueSignal.set(next);
+    },
+    setError(next: unknown): void {
+      valueSignal.set(undefined);
+      errorSignal.set(next);
+    },
+  };
+}

--- a/app/src/app/universities/class-list/class-list.html
+++ b/app/src/app/universities/class-list/class-list.html
@@ -1,7 +1,7 @@
 <section class="class-list">
   <header class="class-list__header">
     <h2>Classes</h2>
-    @if (!showForm()) {
+    @if (!showForm() && !readonly()) {
       <button type="button" (click)="startCreate()">Add class</button>
     }
   </header>
@@ -19,16 +19,18 @@
               · {{ cls.room }}
             }
           </span>
-          <span class="class-list__actions">
-            <button type="button" (click)="startEdit(cls)">Edit</button>
-            <button type="button" (click)="deleteClass(cls)">Delete</button>
-          </span>
+          @if (!readonly()) {
+            <span class="class-list__actions">
+              <button type="button" (click)="startEdit(cls)">Edit</button>
+              <button type="button" (click)="deleteClass(cls)">Delete</button>
+            </span>
+          }
         </li>
       }
     </ul>
   }
 
-  @if (showForm()) {
+  @if (showForm() && !readonly()) {
     <app-class-form
       [universityId]="universityId()"
       [periods]="periods()"

--- a/app/src/app/universities/class-list/class-list.ts
+++ b/app/src/app/universities/class-list/class-list.ts
@@ -16,6 +16,7 @@ export class ClassList {
   readonly universityId = input.required<string>();
   readonly periods = input<Period[]>([]);
   readonly classes = input<ClassResponse[]>([]);
+  readonly readonly = input(false);
 
   protected readonly showForm = signal(false);
   protected readonly editingClass = signal<ClassResponse | undefined>(undefined);

--- a/app/src/app/universities/period-board/period-board.html
+++ b/app/src/app/universities/period-board/period-board.html
@@ -19,19 +19,23 @@
           <label>Label <input type="text" formControlName="label" /></label>
           <label>Starts <input type="datetime-local" formControlName="startsAt" /></label>
           <label>Ends <input type="datetime-local" formControlName="endsAt" /></label>
-          <button type="button" (click)="removeRow(i)">Remove</button>
+          @if (!readonly()) {
+            <button type="button" (click)="removeRow(i)">Remove</button>
+          }
         </fieldset>
       }
     </div>
-    <div class="period-board__actions">
-      <button type="button" (click)="addRow()">Add period</button>
-      <button type="submit" [disabled]="isLoading()">
-        @if (isLoading()) {
-          Saving…
-        } @else {
-          Save periods
-        }
-      </button>
-    </div>
+    @if (!readonly()) {
+      <div class="period-board__actions">
+        <button type="button" (click)="addRow()">Add period</button>
+        <button type="submit" [disabled]="isLoading()">
+          @if (isLoading()) {
+            Saving…
+          } @else {
+            Save periods
+          }
+        </button>
+      </div>
+    }
   </form>
 </section>

--- a/app/src/app/universities/period-board/period-board.ts
+++ b/app/src/app/universities/period-board/period-board.ts
@@ -1,11 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  effect,
-  inject,
-  input,
-  signal,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, input, signal } from '@angular/core';
 import { FormArray, FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import type { ClassResponse, Period, PeriodInput } from '../../api-types/universities-api.types';
 import { Universities } from '../../services/universities';
@@ -24,6 +17,7 @@ export class PeriodBoard {
   readonly universityId = input.required<string>();
   readonly periods = input<Period[]>([]);
   readonly classes = input<ClassResponse[]>([]);
+  readonly readonly = input(false);
 
   protected readonly isLoading = signal(false);
   protected readonly errorMessage = signal('');
@@ -39,6 +33,14 @@ export class PeriodBoard {
     effect(() => {
       this.periods();
       this.syncPeriods();
+    });
+
+    effect(() => {
+      if (this.readonly()) {
+        this.form.disable();
+      } else {
+        this.form.enable();
+      }
     });
   }
 

--- a/app/src/app/universities/universities-dashboard/universities-dashboard.css
+++ b/app/src/app/universities/universities-dashboard/universities-dashboard.css
@@ -48,6 +48,9 @@
 }
 
 .dashboard__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
   font-size: 0.875rem;
   color: var(--color-muted);
 }

--- a/app/src/app/universities/universities-dashboard/universities-dashboard.html
+++ b/app/src/app/universities/universities-dashboard/universities-dashboard.html
@@ -28,7 +28,7 @@
             <a [routerLink]="['/universities', uni.id]" class="dashboard__card">
               <span class="dashboard__title">{{ uni.title }}</span>
               <span class="dashboard__meta">
-                {{ uni.status }} ·
+                <app-status-badge [status]="uni.status" /> ·
                 {{ uni.startDate | date: 'mediumDate' }}
                 @if (uni.endDate) {
                   – {{ uni.endDate | date: 'mediumDate' }}

--- a/app/src/app/universities/universities-dashboard/universities-dashboard.ts
+++ b/app/src/app/universities/universities-dashboard/universities-dashboard.ts
@@ -1,11 +1,12 @@
 import { DatePipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { StatusBadge } from '../../shared/status-badge/status-badge';
 import { Universities } from '../../services/universities';
 
 @Component({
   selector: 'app-universities-dashboard',
-  imports: [RouterLink, DatePipe],
+  imports: [RouterLink, DatePipe, StatusBadge],
   templateUrl: './universities-dashboard.html',
   styleUrl: './universities-dashboard.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/app/src/app/universities/university-editor/university-editor.css
+++ b/app/src/app/universities/university-editor/university-editor.css
@@ -14,12 +14,6 @@
   gap: 0.75rem;
 }
 
-.editor__status {
-  font-size: 0.875rem;
-  color: var(--color-muted);
-  text-transform: uppercase;
-}
-
 .editor__delete {
   margin-inline-start: auto;
   color: var(--color-error);
@@ -33,4 +27,12 @@
 
 .editor__error {
   color: var(--color-error);
+}
+
+.editor__review-note {
+  color: var(--color-error);
+  margin: 0;
+  padding: 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.25rem;
 }

--- a/app/src/app/universities/university-editor/university-editor.html
+++ b/app/src/app/universities/university-editor/university-editor.html
@@ -8,30 +8,54 @@
   } @else if (detail.value(); as data) {
     <header class="editor__header">
       <h1>{{ data.university.title }}</h1>
-      <span class="editor__status">{{ data.university.status }}</span>
+      <app-status-badge [status]="data.university.status" />
       <a [routerLink]="['/universities', universityId(), 'roster']">View rosters</a>
       @if (data.university.status === 'draft') {
         <button type="button" class="editor__delete" (click)="deleteUniversity()">
           Delete draft
         </button>
       }
+      @if (canSubmit()) {
+        <button type="button" [disabled]="actionPending()" (click)="submitForReview()">
+          Submit for review
+        </button>
+      }
+      @if (canClose()) {
+        <button type="button" [disabled]="actionPending()" (click)="closeEvent()">
+          Close event
+        </button>
+      }
     </header>
+
+    @if (actionError(); as message) {
+      <p class="editor__error" role="alert">{{ message }}</p>
+    }
+
+    @if (data.university.status === 'rejected' && data.university.reviewNote) {
+      <p class="editor__review-note" role="status">Rejected: {{ data.university.reviewNote }}</p>
+    }
 
     <section class="editor__section">
       <h2>Details</h2>
-      <app-university-form [universityId]="universityId()" [initial]="data.university" />
+      <app-university-form
+        [universityId]="universityId()"
+        [initial]="data.university"
+        [readonly]="isLocked()"
+      />
     </section>
 
     <app-period-board
       [universityId]="universityId()"
       [periods]="data.university.periods"
       [classes]="data.classes"
+      [readonly]="isLocked()"
     />
 
     <app-class-list
       [universityId]="universityId()"
       [periods]="data.university.periods"
       [classes]="data.classes"
+      [readonly]="isLocked()"
     />
   }
 </main>

--- a/app/src/app/universities/university-editor/university-editor.spec.ts
+++ b/app/src/app/universities/university-editor/university-editor.spec.ts
@@ -1,0 +1,99 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router, RouterOutlet } from '@angular/router';
+import { render, screen } from '@testing-library/angular/zoneless';
+import { describe, expect, it, vi } from 'vitest';
+import type { UniversityStatus } from '../../api-types/universities-api.types';
+import { Universities } from '../../services/universities';
+import { fakeResource } from '../../test-utils/fake-resource';
+import { UniversityEditor } from './university-editor';
+
+@Component({ template: '<router-outlet />', imports: [RouterOutlet] })
+class TestApp {}
+
+describe('UniversityEditor', () => {
+  interface SetupOptions {
+    status?: UniversityStatus;
+    reviewNote?: string | null;
+  }
+
+  async function setup({ status = 'draft', reviewNote = null }: SetupOptions = {}) {
+    const detail = fakeResource({
+      university: {
+        id: 'uni1',
+        title: 'Spring MBU',
+        status,
+        timezone: 'America/New_York',
+        startDate: '2026-06-01T12:00:00.000Z',
+        endDate: null,
+        registrationOpensAt: null,
+        registrationClosesAt: '2026-05-25T23:59:59.000Z',
+        location: {
+          name: 'Scout Hall',
+          address: '1 Main St',
+          city: 'Anytown',
+          state: 'NY',
+          zip: '12345',
+        },
+        periods: [],
+        createdByUid: 'u1',
+        reviewNote,
+        submittedAt: null,
+        createdAt: '2026-07-01T00:00:00.000Z',
+        updatedAt: '2026-07-01T00:00:00.000Z',
+      },
+      classes: [],
+    });
+
+    await render(TestApp, {
+      providers: [
+        provideRouter([{ path: 'universities/:id', component: UniversityEditor }]),
+        {
+          provide: Universities,
+          useValue: {
+            activeUniversityId: signal<string | undefined>(undefined),
+            flashMessage: signal<string | null>(null),
+            detail,
+            openUniversity: vi.fn(),
+            submitUniversity: vi.fn(() => Promise.resolve()),
+            closeUniversity: vi.fn(() => Promise.resolve()),
+            deleteUniversity: vi.fn(() => Promise.resolve()),
+            apiErrorMessage: (_error: unknown, fallback: string) => fallback,
+          },
+        },
+      ],
+    });
+    await TestBed.inject(Router).navigateByUrl('/universities/uni1');
+    await screen.findByText(status);
+  }
+
+  it('shows the status badge and a submit button for a draft event', async () => {
+    await setup({ status: 'draft' });
+
+    expect(screen.getByRole('button', { name: 'Submit for review' })).toBeVisible();
+    expect(screen.queryByRole('button', { name: 'Close event' })).not.toBeInTheDocument();
+  });
+
+  it('shows a close button and no submit button for a published event', async () => {
+    await setup({ status: 'published' });
+
+    expect(screen.getByRole('button', { name: 'Close event' })).toBeVisible();
+    expect(screen.queryByRole('button', { name: 'Submit for review' })).not.toBeInTheDocument();
+  });
+
+  it('shows the rejection note banner and still allows resubmission', async () => {
+    await setup({ status: 'rejected', reviewNote: 'Missing counselor disclaimers' });
+
+    expect(screen.getByText('Rejected: Missing counselor disclaimers')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Submit for review' })).toBeVisible();
+  });
+
+  it('disables the details form and hides class/period actions once submitted', async () => {
+    await setup({ status: 'submitted' });
+
+    expect(screen.getByLabelText('Title')).toBeDisabled();
+    expect(screen.queryByRole('button', { name: 'Save university' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Add class' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Add period' })).not.toBeInTheDocument();
+  });
+});

--- a/app/src/app/universities/university-editor/university-editor.ts
+++ b/app/src/app/universities/university-editor/university-editor.ts
@@ -12,11 +12,15 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { ClassList } from '../class-list/class-list';
 import { PeriodBoard } from '../period-board/period-board';
 import { UniversityForm } from '../university-form/university-form';
+import { StatusBadge } from '../../shared/status-badge/status-badge';
 import { Universities } from '../../services/universities';
+
+const LOCKED_STATUSES = new Set(['submitted', 'published', 'closed']);
+const SUBMITTABLE_STATUSES = new Set(['draft', 'rejected']);
 
 @Component({
   selector: 'app-university-editor',
-  imports: [RouterLink, UniversityForm, PeriodBoard, ClassList],
+  imports: [RouterLink, UniversityForm, PeriodBoard, ClassList, StatusBadge],
   templateUrl: './university-editor.html',
   styleUrl: './university-editor.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -39,6 +43,21 @@ export class UniversityEditor {
     if (error instanceof HttpErrorResponse && error.status === 403) return null;
     return 'Could not load this university.';
   });
+
+  protected readonly isLocked = computed(() =>
+    LOCKED_STATUSES.has(this.detail.value()?.university.status ?? ''),
+  );
+
+  protected readonly canSubmit = computed(() =>
+    SUBMITTABLE_STATUSES.has(this.detail.value()?.university.status ?? ''),
+  );
+
+  protected readonly canClose = computed(
+    () => this.detail.value()?.university.status === 'published',
+  );
+
+  protected readonly actionPending = signal(false);
+  protected readonly actionError = signal('');
 
   constructor() {
     effect(() => {
@@ -65,5 +84,34 @@ export class UniversityEditor {
     }
     await this.universities.deleteUniversity(id);
     await this.router.navigate(['/universities']);
+  }
+
+  protected async submitForReview(): Promise<void> {
+    this.actionError.set('');
+    this.actionPending.set(true);
+    try {
+      await this.universities.submitUniversity(this.universityId());
+    } catch (error) {
+      this.actionError.set(
+        this.universities.apiErrorMessage(error, 'Could not submit for review.'),
+      );
+    } finally {
+      this.actionPending.set(false);
+    }
+  }
+
+  protected async closeEvent(): Promise<void> {
+    if (!globalThis.confirm('Close this event? This cannot be undone.')) {
+      return;
+    }
+    this.actionError.set('');
+    this.actionPending.set(true);
+    try {
+      await this.universities.closeUniversity(this.universityId());
+    } catch (error) {
+      this.actionError.set(this.universities.apiErrorMessage(error, 'Could not close the event.'));
+    } finally {
+      this.actionPending.set(false);
+    }
   }
 }

--- a/app/src/app/universities/university-form/university-form.html
+++ b/app/src/app/universities/university-form/university-form.html
@@ -42,11 +42,13 @@
     <input id="locationZip" type="text" formControlName="locationZip" />
   </fieldset>
 
-  <button type="submit" [disabled]="isLoading()">
-    @if (isLoading()) {
-      Saving…
-    } @else {
-      Save university
-    }
-  </button>
+  @if (!readonly()) {
+    <button type="submit" [disabled]="isLoading()">
+      @if (isLoading()) {
+        Saving…
+      } @else {
+        Save university
+      }
+    </button>
+  }
 </form>

--- a/app/src/app/universities/university-form/university-form.ts
+++ b/app/src/app/universities/university-form/university-form.ts
@@ -30,6 +30,7 @@ export class UniversityForm {
   /** When set, the form edits an existing university; otherwise it creates one. */
   readonly universityId = input<string | undefined>(undefined);
   readonly initial = input<UniversityResponse | undefined>(undefined);
+  readonly readonly = input(false);
 
   readonly saved = output<UniversityResponse>();
 
@@ -54,6 +55,14 @@ export class UniversityForm {
     effect(() => {
       const data = this.initial();
       if (data) this.applyInitial(data);
+    });
+
+    effect(() => {
+      if (this.readonly()) {
+        this.form.disable();
+      } else {
+        this.form.enable();
+      }
     });
   }
 

--- a/firebase.json
+++ b/firebase.json
@@ -108,6 +108,11 @@
           "region": "us-east4"
         },
         {
+          "source": "/api/admin/universities{,/**}",
+          "function": "universitiesApi",
+          "region": "us-east4"
+        },
+        {
           "source": "/api/registrations{,/**}",
           "function": "registrationsApi",
           "region": "us-east4"

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -5,7 +5,7 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "status", "order": "ASCENDING" },
-        { "fieldPath": "submittedAt", "order": "DESCENDING" }
+        { "fieldPath": "submittedAt", "order": "ASCENDING" }
       ]
     },
     {

--- a/functions/src/universities-api/app.test.ts
+++ b/functions/src/universities-api/app.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { DecodedIdToken } from "firebase-admin/auth";
 import {
+  ConflictError,
   ForbiddenError,
   NotFoundError,
   ValidationError,
@@ -26,6 +27,14 @@ const unverified: TokenVerifier = () =>
     email_verified: false,
   } as DecodedIdToken);
 
+const superAdminVerified: TokenVerifier = () =>
+  Promise.resolve({
+    uid: "admin1",
+    email: "admin1@example.com",
+    email_verified: true,
+    superAdmin: true,
+  } as DecodedIdToken);
+
 const sampleUniversity = {
   id: "uni1",
   title: "Spring MBU",
@@ -43,6 +52,8 @@ const sampleUniversity = {
     zip: "12345",
   },
   createdByUid: "u1",
+  reviewNote: null,
+  submittedAt: null,
   createdAt: "2026-07-01T00:00:00.000Z",
   updatedAt: "2026-07-01T00:00:00.000Z",
 };
@@ -127,6 +138,78 @@ const universitiesService: UniversitiesService = {
       classes: [],
     }),
   remove: () => Promise.resolve(),
+  submit: (_caller, universityId) => {
+    if (universityId === "no-classes-uni") {
+      return Promise.reject(
+        new ValidationError(
+          "At least one class is required to submit for review",
+        ),
+      );
+    }
+    if (universityId === "illegal-uni") {
+      return Promise.reject(
+        new ConflictError("Cannot transition from published to submitted"),
+      );
+    }
+    return Promise.resolve({
+      ...sampleUniversity,
+      id: universityId,
+      status: "submitted" as const,
+      submittedAt: "2026-07-04T00:00:00.000Z",
+      reviewNote: null,
+    });
+  },
+  close: (_caller, universityId) =>
+    Promise.resolve({
+      ...sampleUniversity,
+      id: universityId,
+      status: "closed" as const,
+    }),
+  approve: (caller, universityId) => {
+    if (!caller.superAdmin) {
+      return Promise.reject(
+        new ForbiddenError("Super-admin privileges required"),
+      );
+    }
+    return Promise.resolve({
+      ...sampleUniversity,
+      id: universityId,
+      status: "published" as const,
+    });
+  },
+  reject: (caller, universityId, note) => {
+    if (!caller.superAdmin) {
+      return Promise.reject(
+        new ForbiddenError("Super-admin privileges required"),
+      );
+    }
+    return Promise.resolve({
+      ...sampleUniversity,
+      id: universityId,
+      status: "rejected" as const,
+      reviewNote: note,
+    });
+  },
+  listReviewQueue: caller => {
+    if (!caller.superAdmin) {
+      return Promise.reject(
+        new ForbiddenError("Super-admin privileges required"),
+      );
+    }
+    return Promise.resolve({
+      universities: [
+        {
+          id: "uni1",
+          title: "Spring MBU",
+          chancellorName: "Alex Chancellor",
+          chancellorEmail: "alex@example.com",
+          submittedAt: "2026-07-01T00:00:00.000Z",
+          classCount: 2,
+          startDate: sampleUniversity.startDate,
+        },
+      ],
+    });
+  },
 };
 
 const periodsService: PeriodsService = {
@@ -293,6 +376,101 @@ describe("universities-api routes", () => {
       authed("/api/universities/uni1/classes/cls1", "DELETE"),
     );
     expect(response.status).toBe(204);
+  });
+
+  it("POST /api/universities/:id/submit transitions to submitted", async () => {
+    const response = await handleRequest(
+      app(),
+      authed("/api/universities/uni1/submit", "POST"),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { status: string };
+    expect(body.status).toBe("submitted");
+  });
+
+  it("POST /api/universities/:id/submit returns 400 with zero classes", async () => {
+    const response = await handleRequest(
+      app(),
+      authed("/api/universities/no-classes-uni/submit", "POST"),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("POST /api/universities/:id/submit returns 409 on an illegal transition", async () => {
+    const response = await handleRequest(
+      app(),
+      authed("/api/universities/illegal-uni/submit", "POST"),
+    );
+    expect(response.status).toBe(409);
+  });
+
+  it("POST /api/universities/:id/close transitions to closed", async () => {
+    const response = await handleRequest(
+      app(),
+      authed("/api/universities/uni1/close", "POST"),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { status: string };
+    expect(body.status).toBe("closed");
+  });
+});
+
+describe("universities-api admin routes", () => {
+  const adminApp = () =>
+    createApp({
+      universitiesService,
+      periodsService,
+      classesService,
+      verifyToken: superAdminVerified,
+    });
+
+  it("POST /api/admin/universities/:id/approve transitions to published", async () => {
+    const response = await handleRequest(
+      adminApp(),
+      authed("/api/admin/universities/uni1/approve", "POST"),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { status: string };
+    expect(body.status).toBe("published");
+  });
+
+  it("POST /api/admin/universities/:id/reject transitions to rejected with the note", async () => {
+    const response = await handleRequest(
+      adminApp(),
+      authed("/api/admin/universities/uni1/reject", "POST", {
+        note: "Missing counselor disclaimers",
+      }),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      status: string;
+      reviewNote: string | null;
+    };
+    expect(body.status).toBe("rejected");
+    expect(body.reviewNote).toBe("Missing counselor disclaimers");
+  });
+
+  it("GET /api/admin/universities/review-queue returns queued rows", async () => {
+    const response = await handleRequest(
+      adminApp(),
+      authed("/api/admin/universities/review-queue", "GET"),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { universities: unknown[] };
+    expect(body.universities).toHaveLength(1);
+  });
+
+  it("returns 403 when a non-super-admin hits an admin route", async () => {
+    const response = await handleRequest(
+      createApp({
+        universitiesService,
+        periodsService,
+        classesService,
+        verifyToken: verified,
+      }),
+      authed("/api/admin/universities/uni1/approve", "POST"),
+    );
+    expect(response.status).toBe(403);
   });
 });
 

--- a/functions/src/universities-api/app.ts
+++ b/functions/src/universities-api/app.ts
@@ -16,6 +16,8 @@ import {
 } from "./schemas/period-schemas.js";
 import { PublicUniversityResponseSchema } from "./schemas/public-schemas.js";
 import {
+  RejectRequestSchema,
+  ReviewQueueResponseSchema,
   UniversityCreateRequestSchema,
   UniversityListResponseSchema,
   UniversityPatchRequestSchema,
@@ -116,6 +118,32 @@ export function createApp(services?: PartialUniversitiesApiServices) {
         await classes.remove(caller, params.id, params.classId);
         set.status = 204;
       },
+    )
+    .post(
+      "/universities/:id/submit",
+      ({ caller, params }) => universities.submit(caller, params.id),
+      { response: UniversityResponseSchema },
+    )
+    .post(
+      "/universities/:id/close",
+      ({ caller, params }) => universities.close(caller, params.id),
+      { response: UniversityResponseSchema },
+    )
+    .get(
+      "/admin/universities/review-queue",
+      ({ caller }) => universities.listReviewQueue(caller),
+      { response: ReviewQueueResponseSchema },
+    )
+    .post(
+      "/admin/universities/:id/approve",
+      ({ caller, params }) => universities.approve(caller, params.id),
+      { response: UniversityResponseSchema },
+    )
+    .post(
+      "/admin/universities/:id/reject",
+      ({ caller, params, body }) =>
+        universities.reject(caller, params.id, body.note),
+      { body: RejectRequestSchema, response: UniversityResponseSchema },
     );
 }
 

--- a/functions/src/universities-api/schemas/class-schemas.ts
+++ b/functions/src/universities-api/schemas/class-schemas.ts
@@ -93,6 +93,8 @@ export const UniversityDetailResponseSchema = t.Object({
       }),
     ),
     createdByUid: t.String(),
+    reviewNote: t.Union([t.String(), t.Null()]),
+    submittedAt: t.Union([t.String(), t.Null()]),
     createdAt: t.String(),
     updatedAt: t.String(),
   }),

--- a/functions/src/universities-api/schemas/university-schemas.ts
+++ b/functions/src/universities-api/schemas/university-schemas.ts
@@ -66,6 +66,8 @@ export const UniversityResponseSchema = t.Object({
   registrationClosesAt: t.String(),
   location: LocationSchema,
   createdByUid: t.String(),
+  reviewNote: t.Union([t.String(), t.Null()]),
+  submittedAt: t.Union([t.String(), t.Null()]),
   createdAt: t.String(),
   updatedAt: t.String(),
 });
@@ -89,3 +91,24 @@ export const UniversityListResponseSchema = t.Object({
 export type UniversityListResponse = Static<
   typeof UniversityListResponseSchema
 >;
+
+export const RejectRequestSchema = t.Object({
+  note: t.String({ minLength: 1, maxLength: 2000 }),
+});
+export type RejectRequest = Static<typeof RejectRequestSchema>;
+
+export const ReviewQueueRowSchema = t.Object({
+  id: t.String(),
+  title: t.String(),
+  chancellorName: t.String(),
+  chancellorEmail: t.String(),
+  submittedAt: t.Union([t.String(), t.Null()]),
+  classCount: t.Number(),
+  startDate: t.String(),
+});
+export type ReviewQueueRow = Static<typeof ReviewQueueRowSchema>;
+
+export const ReviewQueueResponseSchema = t.Object({
+  universities: t.Array(ReviewQueueRowSchema),
+});
+export type ReviewQueueResponse = Static<typeof ReviewQueueResponseSchema>;

--- a/functions/src/universities-api/services/classes/index.ts
+++ b/functions/src/universities-api/services/classes/index.ts
@@ -34,7 +34,7 @@ import type {
   ClassPatchRequest,
   ClassResponse,
 } from "../../schemas/class-schemas.js";
-import { assertDraftStatus, toIso } from "../validation.js";
+import { assertEditableStatus, toIso } from "../validation.js";
 import type { ClassesService } from "./interface.js";
 
 function toClassResponse(classId: string, doc: ClassDocument): ClassResponse {
@@ -123,7 +123,7 @@ export class ClassesServiceImpl implements ClassesService {
         throw new NotFoundError("University not found");
       }
       const university = uniSnapshot.data() as UniversityDocument;
-      assertDraftStatus(university.status);
+      assertEditableStatus(university.status);
       validatePeriodIds(request.periodIds, university);
 
       const classDoc = {
@@ -197,7 +197,7 @@ export class ClassesServiceImpl implements ClassesService {
       }
 
       const university = uniSnapshot.data() as UniversityDocument;
-      assertDraftStatus(university.status);
+      assertEditableStatus(university.status);
 
       const updates: Record<string, unknown> = {
         updatedAt: FieldValue.serverTimestamp(),
@@ -260,7 +260,7 @@ export class ClassesServiceImpl implements ClassesService {
       if (!classSnapshot.exists) {
         throw new NotFoundError("Class not found");
       }
-      assertDraftStatus((uniSnapshot.data() as UniversityDocument).status);
+      assertEditableStatus((uniSnapshot.data() as UniversityDocument).status);
 
       const grantsQuery = this.db()
         .collection(ROLE_GRANTS_COLLECTION)

--- a/functions/src/universities-api/services/periods/index.ts
+++ b/functions/src/universities-api/services/periods/index.ts
@@ -25,7 +25,7 @@ import type {
   PeriodsResponse,
 } from "../../schemas/period-schemas.js";
 import {
-  assertDraftStatus,
+  assertEditableStatus,
   mintPeriodId,
   parseIso,
   toIso,
@@ -109,7 +109,7 @@ export class PeriodsServiceImpl implements PeriodsService {
         throw new NotFoundError("University not found");
       }
       const current = snapshot.data() as UniversityDocument;
-      assertDraftStatus(current.status);
+      assertEditableStatus(current.status);
 
       const nextPeriods = buildPeriods(request.periods, current.periods);
       const nextIds = new Set(nextPeriods.map(p => p.periodId));

--- a/functions/src/universities-api/services/transitions.test.ts
+++ b/functions/src/universities-api/services/transitions.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import type { UniversityStatus } from "../../collections/universities.js";
+import { ConflictError } from "../../shared-api/errors/http-error.js";
+import { assertTransition } from "./transitions.js";
+
+const ALL_STATUSES: UniversityStatus[] = [
+  "draft",
+  "submitted",
+  "needs_review",
+  "published",
+  "closed",
+  "rejected",
+];
+
+const LEGAL_EDGES: [UniversityStatus, UniversityStatus][] = [
+  ["draft", "submitted"],
+  ["rejected", "submitted"],
+  ["submitted", "published"],
+  ["submitted", "rejected"],
+  ["published", "closed"],
+];
+
+describe("assertTransition", () => {
+  for (const [from, to] of LEGAL_EDGES) {
+    it(`allows ${from} -> ${to}`, () => {
+      expect(() => assertTransition(from, to)).not.toThrow();
+    });
+  }
+
+  const legalSet = new Set(LEGAL_EDGES.map(([from, to]) => `${from}->${to}`));
+  for (const from of ALL_STATUSES) {
+    for (const to of ALL_STATUSES) {
+      if (legalSet.has(`${from}->${to}`)) continue;
+      it(`rejects ${from} -> ${to}`, () => {
+        expect(() => assertTransition(from, to)).toThrow(ConflictError);
+      });
+    }
+  }
+});

--- a/functions/src/universities-api/services/transitions.ts
+++ b/functions/src/universities-api/services/transitions.ts
@@ -1,0 +1,21 @@
+import type { UniversityStatus } from "../../collections/universities.js";
+import { ConflictError } from "../../shared-api/errors/http-error.js";
+
+const LEGAL_TRANSITIONS: Record<UniversityStatus, UniversityStatus[]> = {
+  draft: ["submitted"],
+  rejected: ["submitted"],
+  submitted: ["published", "rejected"],
+  published: ["closed"],
+  closed: [],
+  needs_review: [],
+};
+
+/** Pure from→to legality check. Actor authorization is enforced separately by the caller. */
+export function assertTransition(
+  from: UniversityStatus,
+  to: UniversityStatus,
+): void {
+  if (!LEGAL_TRANSITIONS[from].includes(to)) {
+    throw new ConflictError(`Cannot transition from ${from} to ${to}`);
+  }
+}

--- a/functions/src/universities-api/services/universities/index.ts
+++ b/functions/src/universities-api/services/universities/index.ts
@@ -18,11 +18,18 @@ import {
   type UniversityDocument,
 } from "../../../collections/universities.js";
 import {
+  USERS_COLLECTION,
+  type UserDocument,
+} from "../../../collections/users.js";
+import {
   ConflictError,
   NotFoundError,
   ValidationError,
 } from "../../../shared-api/errors/http-error.js";
-import { assertChancellorOf } from "../../../shared-api/services/authz/assertions.js";
+import {
+  assertChancellorOf,
+  requireSuperAdmin,
+} from "../../../shared-api/services/authz/assertions.js";
 import type { Caller } from "../../../shared-api/types/caller.js";
 import type {
   ClassResponse,
@@ -30,13 +37,16 @@ import type {
 } from "../../schemas/class-schemas.js";
 import type { PublicUniversityResponse } from "../../schemas/public-schemas.js";
 import type {
+  ReviewQueueResponse,
   UniversityCreateRequest,
   UniversityListResponse,
   UniversityPatchRequest,
   UniversityResponse,
 } from "../../schemas/university-schemas.js";
+import { assertTransition } from "../transitions.js";
 import {
   assertDraftStatus,
+  assertEditableStatus,
   parseIso,
   toIso,
   validateDateOrder,
@@ -60,6 +70,8 @@ function toUniversityResponse(
     registrationClosesAt: toIso(doc.registrationClosesAt) ?? "",
     location: doc.location,
     createdByUid: doc.createdByUid,
+    reviewNote: doc.reviewNote,
+    submittedAt: toIso(doc.submittedAt),
     createdAt: toIso(doc.createdAt) ?? "",
     updatedAt: toIso(doc.updatedAt) ?? "",
   };
@@ -239,7 +251,7 @@ export class UniversitiesServiceImpl implements UniversitiesService {
       throw new NotFoundError("University not found");
     }
     const current = snapshot.data() as UniversityDocument;
-    assertDraftStatus(current.status);
+    assertEditableStatus(current.status);
 
     const updates: Record<string, unknown> = {
       updatedAt: FieldValue.serverTimestamp(),
@@ -442,6 +454,8 @@ export class UniversitiesServiceImpl implements UniversitiesService {
           endsAt: toIso(p.endsAt) ?? "",
         })),
         createdByUid: doc.createdByUid,
+        reviewNote: doc.reviewNote,
+        submittedAt: toIso(doc.submittedAt),
         createdAt: toIso(doc.createdAt) ?? "",
         updatedAt: toIso(doc.updatedAt) ?? "",
       },
@@ -482,6 +496,185 @@ export class UniversitiesServiceImpl implements UniversitiesService {
     }
     batch.delete(universityRef);
     await batch.commit();
+  }
+
+  async submit(
+    caller: Caller,
+    universityId: string,
+  ): Promise<UniversityResponse> {
+    await assertChancellorOf(caller, universityId);
+
+    const universityRef = this.db()
+      .collection(UNIVERSITIES_COLLECTION)
+      .doc(universityId);
+
+    await this.db().runTransaction(async txn => {
+      const snapshot = await txn.get(universityRef);
+      if (!snapshot.exists) {
+        throw new NotFoundError("University not found");
+      }
+      const current = snapshot.data() as UniversityDocument;
+      assertTransition(current.status, "submitted");
+
+      const classesSnapshot = await txn.get(
+        this.db()
+          .collection(
+            `${UNIVERSITIES_COLLECTION}/${universityId}/${CLASSES_SUBCOLLECTION}`,
+          )
+          .limit(1),
+      );
+      if (classesSnapshot.empty) {
+        throw new ValidationError(
+          "At least one class is required to submit for review",
+        );
+      }
+
+      txn.update(universityRef, {
+        status: "submitted",
+        submittedAt: FieldValue.serverTimestamp(),
+        reviewNote: null,
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+    });
+
+    return toUniversityResponse(
+      universityId,
+      (await universityRef.get()).data() as UniversityDocument,
+    );
+  }
+
+  async close(
+    caller: Caller,
+    universityId: string,
+  ): Promise<UniversityResponse> {
+    await assertChancellorOf(caller, universityId);
+
+    const universityRef = this.db()
+      .collection(UNIVERSITIES_COLLECTION)
+      .doc(universityId);
+
+    await this.db().runTransaction(async txn => {
+      const snapshot = await txn.get(universityRef);
+      if (!snapshot.exists) {
+        throw new NotFoundError("University not found");
+      }
+      const current = snapshot.data() as UniversityDocument;
+      assertTransition(current.status, "closed");
+
+      txn.update(universityRef, {
+        status: "closed",
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+    });
+
+    return toUniversityResponse(
+      universityId,
+      (await universityRef.get()).data() as UniversityDocument,
+    );
+  }
+
+  async approve(
+    caller: Caller,
+    universityId: string,
+  ): Promise<UniversityResponse> {
+    requireSuperAdmin(caller);
+
+    const universityRef = this.db()
+      .collection(UNIVERSITIES_COLLECTION)
+      .doc(universityId);
+
+    await this.db().runTransaction(async txn => {
+      const snapshot = await txn.get(universityRef);
+      if (!snapshot.exists) {
+        throw new NotFoundError("University not found");
+      }
+      const current = snapshot.data() as UniversityDocument;
+      assertTransition(current.status, "published");
+
+      txn.update(universityRef, {
+        status: "published",
+        publishedAt: FieldValue.serverTimestamp(),
+        reviewNote: null,
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+    });
+
+    return toUniversityResponse(
+      universityId,
+      (await universityRef.get()).data() as UniversityDocument,
+    );
+  }
+
+  async reject(
+    caller: Caller,
+    universityId: string,
+    note: string,
+  ): Promise<UniversityResponse> {
+    requireSuperAdmin(caller);
+
+    const universityRef = this.db()
+      .collection(UNIVERSITIES_COLLECTION)
+      .doc(universityId);
+
+    await this.db().runTransaction(async txn => {
+      const snapshot = await txn.get(universityRef);
+      if (!snapshot.exists) {
+        throw new NotFoundError("University not found");
+      }
+      const current = snapshot.data() as UniversityDocument;
+      assertTransition(current.status, "rejected");
+
+      txn.update(universityRef, {
+        status: "rejected",
+        reviewNote: note,
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+    });
+
+    return toUniversityResponse(
+      universityId,
+      (await universityRef.get()).data() as UniversityDocument,
+    );
+  }
+
+  async listReviewQueue(caller: Caller): Promise<ReviewQueueResponse> {
+    requireSuperAdmin(caller);
+
+    const snapshot = await this.db()
+      .collection(UNIVERSITIES_COLLECTION)
+      .where("status", "==", "submitted")
+      .orderBy("submittedAt", "asc")
+      .get();
+
+    const universities = await Promise.all(
+      snapshot.docs.map(async doc => {
+        const data = doc.data() as UniversityDocument;
+        const [classCountResult, userSnapshot] = await Promise.all([
+          this.db()
+            .collection(
+              `${UNIVERSITIES_COLLECTION}/${doc.id}/${CLASSES_SUBCOLLECTION}`,
+            )
+            .count()
+            .get(),
+          this.db().collection(USERS_COLLECTION).doc(data.createdByUid).get(),
+        ]);
+        const user = userSnapshot.exists
+          ? (userSnapshot.data() as UserDocument)
+          : null;
+
+        return {
+          id: doc.id,
+          title: data.title,
+          chancellorName: user?.displayName ?? "",
+          chancellorEmail: user?.email ?? "",
+          submittedAt: toIso(data.submittedAt),
+          classCount: classCountResult.data().count,
+          startDate: toIso(data.startDate) ?? "",
+        };
+      }),
+    );
+
+    return { universities };
   }
 }
 

--- a/functions/src/universities-api/services/universities/interface.ts
+++ b/functions/src/universities-api/services/universities/interface.ts
@@ -2,6 +2,7 @@ import type { Caller } from "../../../shared-api/types/caller.js";
 import type { UniversityDetailResponse } from "../../schemas/class-schemas.js";
 import type { PublicUniversityResponse } from "../../schemas/public-schemas.js";
 import type {
+  ReviewQueueResponse,
   UniversityCreateRequest,
   UniversityListResponse,
   UniversityPatchRequest,
@@ -25,4 +26,13 @@ export interface UniversitiesService {
     universityId: string,
   ): Promise<UniversityDetailResponse>;
   remove(caller: Caller, universityId: string): Promise<void>;
+  submit(caller: Caller, universityId: string): Promise<UniversityResponse>;
+  close(caller: Caller, universityId: string): Promise<UniversityResponse>;
+  approve(caller: Caller, universityId: string): Promise<UniversityResponse>;
+  reject(
+    caller: Caller,
+    universityId: string,
+    note: string,
+  ): Promise<UniversityResponse>;
+  listReviewQueue(caller: Caller): Promise<ReviewQueueResponse>;
 }

--- a/functions/src/universities-api/services/validation.ts
+++ b/functions/src/universities-api/services/validation.ts
@@ -53,6 +53,14 @@ export function assertDraftStatus(status: string): void {
   }
 }
 
+export function assertEditableStatus(status: string): void {
+  if (status !== "draft" && status !== "rejected") {
+    throw new ValidationError(
+      "Only draft or rejected universities can be modified",
+    );
+  }
+}
+
 export function mintPeriodId(): string {
   return crypto.randomUUID();
 }


### PR DESCRIPTION
Closes #87.

Wires the event lifecycle transitions and a super-admin review queue onto the existing status scaffolding (the `UniversityDocument` status union and `submittedAt`/`publishedAt`/`reviewNote` fields already existed; only `draft` was ever written).

## State machine (v1)
- `draft → submitted` (chancellor)
- `rejected → submitted` (chancellor, resubmit — clears `reviewNote`)
- `submitted → published` (super-admin approve — clears `reviewNote`, stamps `publishedAt`)
- `submitted → rejected` (super-admin reject — note required, stamps `reviewNote`)
- `published → closed` (chancellor **or** super-admin)

All other transitions → **409**. Each runs in a Firestore txn that asserts the legal from-state via a pure transition matrix. `needs_review`/auto fork stays in the union but is never written in v1.

## Backend (`universities-api`)
- New routes: `POST /universities/:id/submit`, `POST /universities/:id/close`, `POST /admin/universities/:id/approve`, `POST /admin/universities/:id/reject`, `GET /admin/universities/review-queue` (FIFO by `submittedAt`).
- `assertEditableStatus` (draft **or** rejected) replaces `assertDraftStatus` at content-mutation sites; delete stays draft-only.
- Submit requires ≥1 class (in-txn `limit(1)` read → 400).
- `reviewNote`/`submittedAt` added to detail + response DTOs.
- `firebase.json` + `proxy.conf.json` rewrite for `/api/admin/universities` → `universitiesApi`; Firestore index flipped to `submittedAt ASC`.

## Frontend
- `status-badge` component, `reviewNote` banner, status-gated Submit/Close buttons, editing lockout propagated into the form / period-board / class-list.
- `requireSuperAdmin` guard + `Auth.ensureSuperAdmin()`; `/admin/review` queue + detail (Approve / Reject-with-note).
- `reviewQueue` resource gated behind explicit activation so it never 403s for non-super-admins who inject `Universities` on other pages.

## Testing
- Transition-matrix unit tests, route tests (mocked service, no emulator), guard + component specs.
- Backend: 64 pass. Frontend: 58 pass. `tsc` + eslint + prettier clean on both packages.

## Deferred (follow-up issue)
Moderation emails, `needs_review`/auto-publish fork, LLM triage, report path, delegated moderators, auto-close on `endDate`, dedicated `suspended` state.