### PR TITLE
Add versioned, affirmative parental consent — issue #88

### DIFF
--- a/app/e2e/tests/registration.spec.ts
+++ b/app/e2e/tests/registration.spec.ts
@@ -228,6 +228,9 @@ test.describe('parent registration flow', () => {
     const cookingCard = page.locator('.register__class-card', { hasText: 'Cooking' });
     await expect(cookingCard.getByRole('button', { name: 'Register' })).toBeVisible();
 
+    // Consent gates registration for the selected scout — accept before registering.
+    await page.getByRole('checkbox').check();
+
     // First attempt: UI thought seats were open, backend says the class just filled.
     await cookingCard.getByRole('button', { name: 'Register' }).click();
     await expect(

--- a/app/src/app/api-types/registrations-api.types.ts
+++ b/app/src/app/api-types/registrations-api.types.ts
@@ -1,6 +1,7 @@
 export interface RegisterRequest {
   scoutId: string;
   acceptWaitlist?: boolean;
+  acceptConsent: boolean;
 }
 
 export type RegistrationStatus = 'enrolled' | 'waitlisted';

--- a/app/src/app/api-types/users-api.types.ts
+++ b/app/src/app/api-types/users-api.types.ts
@@ -8,6 +8,7 @@ export interface UserResponse {
   phone: string | null;
   acceptedTermsAt: string | null;
   acceptedPrivacyAt: string | null;
+  acceptedPolicyVersion: string | null;
 }
 
 /** Bootstrap result: the user doc plus whether onboarding/consent is still required. */

--- a/app/src/app/app.routes.ts
+++ b/app/src/app/app.routes.ts
@@ -23,6 +23,14 @@ export const routes: Routes = [
     loadComponent: () => import('./sign-in/sign-in').then((m) => m.SignIn),
   },
   {
+    path: 'privacy',
+    loadComponent: () => import('./privacy/privacy').then((m) => m.Privacy),
+  },
+  {
+    path: 'terms',
+    loadComponent: () => import('./terms/terms').then((m) => m.Terms),
+  },
+  {
     path: 'verify-email',
     canActivate: [requireAuth],
     loadComponent: () => import('./verify-email/verify-email').then((m) => m.VerifyEmail),

--- a/app/src/app/guards/auth-guards.spec.ts
+++ b/app/src/app/guards/auth-guards.spec.ts
@@ -182,6 +182,7 @@ function fakeUser() {
     phone: null,
     acceptedTermsAt: null,
     acceptedPrivacyAt: null,
+    acceptedPolicyVersion: null,
   };
 }
 

--- a/app/src/app/onboarding/onboarding.html
+++ b/app/src/app/onboarding/onboarding.html
@@ -15,7 +15,8 @@
 
     <label class="onboarding__checkbox">
       <input type="checkbox" formControlName="acceptedTerms" />
-      I agree to the Terms and Privacy Policy
+      I agree to the <a routerLink="/terms">Terms</a> and
+      <a routerLink="/privacy">Privacy Policy</a>
     </label>
     @if (form.get('acceptedTerms')?.invalid && form.get('acceptedTerms')?.touched) {
       <p class="onboarding__error">You must accept the Terms and Privacy Policy.</p>

--- a/app/src/app/onboarding/onboarding.ts
+++ b/app/src/app/onboarding/onboarding.ts
@@ -1,22 +1,14 @@
 import { HttpClient } from '@angular/common/http';
 import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
-import {
-  FormBuilder,
-  ReactiveFormsModule,
-  Validators,
-  type FormGroup,
-} from '@angular/forms';
-import { Router } from '@angular/router';
+import { FormBuilder, ReactiveFormsModule, Validators, type FormGroup } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
-import type {
-  OnboardingRequest,
-  UserResponse,
-} from '../api-types/users-api.types';
+import type { OnboardingRequest, UserResponse } from '../api-types/users-api.types';
 import { Auth } from '../services/auth';
 
 @Component({
   selector: 'app-onboarding',
-  imports: [ReactiveFormsModule],
+  imports: [ReactiveFormsModule, RouterLink],
   templateUrl: './onboarding.html',
   styleUrl: './onboarding.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -31,10 +23,7 @@ export class Onboarding {
   protected readonly errorMessage = signal('');
 
   protected readonly form: FormGroup = this.fb.group({
-    displayName: [
-      this.auth.currentUser?.displayName ?? '',
-      [Validators.required],
-    ],
+    displayName: [this.auth.currentUser?.displayName ?? '', [Validators.required]],
     acceptedTerms: [false, [Validators.requiredTrue]],
   });
 
@@ -50,9 +39,7 @@ export class Onboarding {
     const body: OnboardingRequest = { displayName, acceptedTerms: true };
 
     try {
-      await firstValueFrom(
-        this.httpClient.patch<UserResponse>('/api/users/me', body),
-      );
+      await firstValueFrom(this.httpClient.patch<UserResponse>('/api/users/me', body));
       await this.router.navigate(['/']);
     } catch {
       this.errorMessage.set('Could not save your details. Please try again.');

--- a/app/src/app/privacy/privacy.html
+++ b/app/src/app/privacy/privacy.html
@@ -1,0 +1,4 @@
+<main class="privacy">
+  <h1>Privacy Policy</h1>
+  <p>This page is coming soon.</p>
+</main>

--- a/app/src/app/privacy/privacy.ts
+++ b/app/src/app/privacy/privacy.ts
@@ -1,0 +1,8 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+  selector: 'app-privacy',
+  templateUrl: './privacy.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class Privacy {}

--- a/app/src/app/register/register.html
+++ b/app/src/app/register/register.html
@@ -103,7 +103,7 @@
                     </p>
                     <button
                       type="button"
-                      [disabled]="pendingClassId() === cls.classId || !consentAccepted()"
+                      [disabled]="pendingClassId() === cls.classId"
                       (click)="onCancel(cls)"
                     >
                       Drop

--- a/app/src/app/register/register.html
+++ b/app/src/app/register/register.html
@@ -61,6 +61,17 @@
         }
       </section>
 
+      <section class="register__consent">
+        <label>
+          <input
+            type="checkbox"
+            [checked]="consentAccepted()"
+            (change)="consentAccepted.set($any($event.target).checked)"
+          />
+          {{ consentLabel() }}
+        </label>
+      </section>
+
       @if (actionError()) {
         <p class="register__error" role="alert">{{ actionError() }}</p>
       }
@@ -92,7 +103,7 @@
                     </p>
                     <button
                       type="button"
-                      [disabled]="pendingClassId() === cls.classId"
+                      [disabled]="pendingClassId() === cls.classId || !consentAccepted()"
                       (click)="onCancel(cls)"
                     >
                       Drop
@@ -106,14 +117,18 @@
                     </button>
                   } @else if (waitlistPromptClassId() === cls.classId) {
                     <p>This class is full. Join the waitlist instead?</p>
-                    <button type="button" (click)="confirmWaitlist(cls, true)">
+                    <button
+                      type="button"
+                      [disabled]="!consentAccepted()"
+                      (click)="confirmWaitlist(cls, true)"
+                    >
                       Join waitlist
                     </button>
                     <button type="button" (click)="confirmWaitlist(cls, false)">Cancel</button>
                   } @else {
                     <button
                       type="button"
-                      [disabled]="pendingClassId() === cls.classId"
+                      [disabled]="pendingClassId() === cls.classId || !consentAccepted()"
                       (click)="onRegister(cls)"
                     >
                       {{ cls.seatsRemaining <= 0 ? 'Join waitlist' : 'Register' }}

--- a/app/src/app/register/register.spec.ts
+++ b/app/src/app/register/register.spec.ts
@@ -1,6 +1,6 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { signal, type WritableSignal } from '@angular/core';
-import { render, screen, within } from '@testing-library/angular/zoneless';
+import { render, screen, waitFor, within } from '@testing-library/angular/zoneless';
 import { ActivatedRoute, convertToParamMap } from '@angular/router';
 import { of } from 'rxjs';
 import { describe, expect, it } from 'vitest';
@@ -25,10 +25,26 @@ const sampleEvent: PublicUniversity = {
   endDate: null,
   registrationOpensAt: null,
   registrationClosesAt: '2026-05-25T23:59:59.000Z',
-  location: { name: 'Scout Hall', address: '1 Main St', city: 'Anytown', state: 'NY', zip: '12345' },
+  location: {
+    name: 'Scout Hall',
+    address: '1 Main St',
+    city: 'Anytown',
+    state: 'NY',
+    zip: '12345',
+  },
   periods: [
-    { periodId: 'p1', label: 'Period 1', startsAt: '2026-06-01T13:00:00.000Z', endsAt: '2026-06-01T14:00:00.000Z' },
-    { periodId: 'p2', label: 'Period 2', startsAt: '2026-06-01T14:00:00.000Z', endsAt: '2026-06-01T15:00:00.000Z' },
+    {
+      periodId: 'p1',
+      label: 'Period 1',
+      startsAt: '2026-06-01T13:00:00.000Z',
+      endsAt: '2026-06-01T14:00:00.000Z',
+    },
+    {
+      periodId: 'p2',
+      label: 'Period 2',
+      startsAt: '2026-06-01T14:00:00.000Z',
+      endsAt: '2026-06-01T15:00:00.000Z',
+    },
   ],
   classes: [
     // Camping is full — its default action is "Join waitlist".
@@ -192,7 +208,7 @@ describe('Register component', () => {
     expect(await screen.findByText(/Conflicts with Archery/)).toBeVisible();
   });
 
-  it('counts a waitlisted class toward the scout\'s scheduled periods', async () => {
+  it("counts a waitlisted class toward the scout's scheduled periods", async () => {
     await setup({ registrations: [registrationFor('archery', 'waitlisted')] });
 
     expect(await screen.findByText('1/2 periods scheduled')).toBeVisible();
@@ -201,7 +217,11 @@ describe('Register component', () => {
   it('marks the class as registered after the scout registers', async () => {
     await setup({ registerOutcome: 'enrolled' });
 
+    screen.getByRole('checkbox').click();
     const archeryCard = (await screen.findByText('Archery')).closest('li') as HTMLElement;
+    await waitFor(() =>
+      expect(within(archeryCard).getByRole('button', { name: 'Register' })).toBeEnabled(),
+    );
     within(archeryCard).getByRole('button', { name: 'Register' }).click();
 
     expect(await within(archeryCard).findByText('Registered')).toBeVisible();
@@ -211,13 +231,39 @@ describe('Register component', () => {
   it('offers the waitlist when a class turns out to be full, then shows the scout as waitlisted', async () => {
     await setup({ registerOutcome: 'full-then-waitlist' });
 
+    screen.getByRole('checkbox').click();
     const archeryCard = (await screen.findByText('Archery')).closest('li') as HTMLElement;
+    await waitFor(() =>
+      expect(within(archeryCard).getByRole('button', { name: 'Register' })).toBeEnabled(),
+    );
     within(archeryCard).getByRole('button', { name: 'Register' }).click();
 
     expect(await within(archeryCard).findByText(/This class is full/)).toBeVisible();
     within(archeryCard).getByRole('button', { name: 'Join waitlist' }).click();
 
     expect(await within(archeryCard).findByText('On waitlist')).toBeVisible();
+  });
+
+  it('disables Register and Drop until the consent checkbox is checked', async () => {
+    await setup({ registrations: [registrationFor('archery', 'enrolled')] });
+
+    const archeryCard = (await screen.findByText('Archery')).closest('li') as HTMLElement;
+    const hikingCard = (await screen.findByText('Hiking')).closest('li') as HTMLElement;
+    expect(within(archeryCard).getByRole('button', { name: 'Drop' })).toBeDisabled();
+    expect(within(hikingCard).getByRole('button', { name: 'Register' })).toBeDisabled();
+
+    screen.getByRole('checkbox').click();
+
+    await waitFor(() => {
+      expect(within(archeryCard).getByRole('button', { name: 'Drop' })).toBeEnabled();
+      expect(within(hikingCard).getByRole('button', { name: 'Register' })).toBeEnabled();
+    });
+  });
+
+  it('shows a single consent checkbox for the whole event', async () => {
+    await setup();
+
+    expect(screen.getAllByRole('checkbox')).toHaveLength(1);
   });
 
   it('prompts the caller to add a scout when they have none', async () => {

--- a/app/src/app/register/register.spec.ts
+++ b/app/src/app/register/register.spec.ts
@@ -244,19 +244,44 @@ describe('Register component', () => {
     expect(await within(archeryCard).findByText('On waitlist')).toBeVisible();
   });
 
-  it('disables Register and Drop until the consent checkbox is checked', async () => {
+  it('gates Register on consent but keeps Drop available', async () => {
     await setup({ registrations: [registrationFor('archery', 'enrolled')] });
 
     const archeryCard = (await screen.findByText('Archery')).closest('li') as HTMLElement;
     const hikingCard = (await screen.findByText('Hiking')).closest('li') as HTMLElement;
-    expect(within(archeryCard).getByRole('button', { name: 'Drop' })).toBeDisabled();
+    // Dropping withdraws data, so it never requires a fresh share-consent.
+    expect(within(archeryCard).getByRole('button', { name: 'Drop' })).toBeEnabled();
     expect(within(hikingCard).getByRole('button', { name: 'Register' })).toBeDisabled();
 
     screen.getByRole('checkbox').click();
 
+    await waitFor(() =>
+      expect(within(hikingCard).getByRole('button', { name: 'Register' })).toBeEnabled(),
+    );
+  });
+
+  it('requires fresh consent after switching to another scout', async () => {
+    const bailey: ScoutResponse = {
+      ...alexSmith,
+      scoutId: 'scout2',
+      firstName: 'Bailey',
+      lastName: 'Jones',
+    };
+    await setup({ scouts: [alexSmith, bailey] });
+
+    // Consent for the first (default-selected) scout enables Register.
+    const hikingCard = (await screen.findByText('Hiking')).closest('li') as HTMLElement;
+    screen.getByRole('checkbox').click();
+    await waitFor(() =>
+      expect(within(hikingCard).getByRole('button', { name: 'Register' })).toBeEnabled(),
+    );
+
+    // Switching scouts clears consent — the box unchecks and Register re-disables.
+    screen.getByRole('button', { name: 'Bailey Jones' }).click();
+
     await waitFor(() => {
-      expect(within(archeryCard).getByRole('button', { name: 'Drop' })).toBeEnabled();
-      expect(within(hikingCard).getByRole('button', { name: 'Register' })).toBeEnabled();
+      expect(screen.getByRole('checkbox')).not.toBeChecked();
+      expect(within(hikingCard).getByRole('button', { name: 'Register' })).toBeDisabled();
     });
   });
 

--- a/app/src/app/register/register.ts
+++ b/app/src/app/register/register.ts
@@ -10,11 +10,7 @@ import {
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
-import type {
-  ApiErrorBody,
-  Period,
-  PublicClass,
-} from '../api-types/universities-api.types';
+import type { ApiErrorBody, Period, PublicClass } from '../api-types/universities-api.types';
 import type { RegistrationResponse } from '../api-types/registrations-api.types';
 import type { ScoutResponse } from '../api-types/users-api.types';
 import { Registrations } from '../services/registrations';
@@ -51,6 +47,7 @@ export class Register {
   protected readonly actionError = signal('');
   protected readonly pendingClassId = signal<string | undefined>(undefined);
   protected readonly waitlistPromptClassId = signal<string | undefined>(undefined);
+  protected readonly consentAccepted = signal(false);
 
   protected readonly scoutList = computed(() => this.scouts.mine.value()?.scouts ?? []);
 
@@ -61,9 +58,7 @@ export class Register {
     return list.filter((s) => `${s.firstName} ${s.lastName}`.toLowerCase().includes(filter));
   });
 
-  protected readonly registrationsList = computed(
-    () => this.schedule.value()?.registrations ?? [],
-  );
+  protected readonly registrationsList = computed(() => this.schedule.value()?.registrations ?? []);
 
   protected readonly selectedScoutRegistrations = computed(() => {
     const scoutId = this.selectedScoutId();
@@ -75,6 +70,13 @@ export class Register {
     const ev = this.event.value();
     if (!ev) return null;
     return scoutProgress(this.selectedScoutRegistrations(), ev.periods.length);
+  });
+
+  protected readonly consentLabel = computed(() => {
+    const scout = this.scoutList().find((s) => s.scoutId === this.selectedScoutId());
+    const scoutName = scout ? `${scout.firstName} ${scout.lastName}` : 'your scout';
+    const universityTitle = this.event.value()?.title ?? 'this event';
+    return `I consent to share ${scoutName}'s information with the organizers of ${universityTitle}.`;
   });
 
   constructor() {
@@ -129,12 +131,14 @@ export class Register {
     scoutId: string,
     acceptWaitlist: boolean,
   ): Promise<void> {
+    if (!this.consentAccepted()) return;
     this.actionError.set('');
     this.pendingClassId.set(cls.classId);
     try {
       await this.registrations.register(this.universityId(), cls.classId, {
         scoutId,
         acceptWaitlist,
+        acceptConsent: true,
       });
       this.universities.reloadPublicEvent();
     } catch (error) {
@@ -158,7 +162,7 @@ export class Register {
 
   protected async onCancel(cls: PublicClass): Promise<void> {
     const scoutId = this.selectedScoutId();
-    if (!scoutId) return;
+    if (!scoutId || !this.consentAccepted()) return;
     if (!globalThis.confirm(`Drop ${cls.badgeTitle}?`)) return;
 
     this.actionError.set('');

--- a/app/src/app/register/register.ts
+++ b/app/src/app/register/register.ts
@@ -98,13 +98,16 @@ export class Register {
   }
 
   protected selectScout(scoutId: string): void {
+    if (scoutId === this.selectedScoutId()) return;
     this.selectedScoutId.set(scoutId);
     this.actionError.set('');
+    // Consent is per scout per event: switching scouts requires a fresh act.
+    this.consentAccepted.set(false);
   }
 
   protected onScoutAdded(scout: ScoutResponse): void {
     this.showAddScout.set(false);
-    this.selectedScoutId.set(scout.scoutId);
+    this.selectScout(scout.scoutId);
   }
 
   protected periodClasses(period: Period): PublicClass[] {
@@ -162,7 +165,7 @@ export class Register {
 
   protected async onCancel(cls: PublicClass): Promise<void> {
     const scoutId = this.selectedScoutId();
-    if (!scoutId || !this.consentAccepted()) return;
+    if (!scoutId) return;
     if (!globalThis.confirm(`Drop ${cls.badgeTitle}?`)) return;
 
     this.actionError.set('');

--- a/app/src/app/terms/terms.html
+++ b/app/src/app/terms/terms.html
@@ -1,0 +1,4 @@
+<main class="terms">
+  <h1>Terms of Service</h1>
+  <p>This page is coming soon.</p>
+</main>

--- a/app/src/app/terms/terms.ts
+++ b/app/src/app/terms/terms.ts
@@ -1,0 +1,8 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+  selector: 'app-terms',
+  templateUrl: './terms.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class Terms {}

--- a/functions/src/collections/registrations.ts
+++ b/functions/src/collections/registrations.ts
@@ -47,6 +47,8 @@ export interface RegistrationDocument {
   waitlistedAt: Timestamp | null;
   enrolledAt: Timestamp | null;
   parentConsentAt: Timestamp | null;
+  /** POLICY_VERSION in effect when parentConsentAt was stamped. */
+  acceptedPolicyVersion: string | null;
   createdAt: Timestamp;
   updatedAt: Timestamp;
 }

--- a/functions/src/collections/users.ts
+++ b/functions/src/collections/users.ts
@@ -22,6 +22,8 @@ export interface UserDocument {
   counselorProfile: CounselorProfile | null;
   acceptedTermsAt: Timestamp | null;
   acceptedPrivacyAt: Timestamp | null;
+  /** POLICY_VERSION in effect when onboarding consent was accepted. */
+  acceptedPolicyVersion: string | null;
   createdAt: Timestamp;
   updatedAt: Timestamp;
 }

--- a/functions/src/constants/privacy.ts
+++ b/functions/src/constants/privacy.ts
@@ -1,0 +1,2 @@
+/** Version string stamped on parental consent and account-onboarding acceptance. */
+export const POLICY_VERSION = "2026-07-04";

--- a/functions/src/registrations-api/app.test.ts
+++ b/functions/src/registrations-api/app.test.ts
@@ -181,6 +181,7 @@ describe("POST /api/registrations/:universityId/:classId", () => {
     const { request } = setup();
     const response = await request("/api/registrations/uni1/cls1", "POST", {
       scoutId: "scout1",
+      acceptConsent: true,
     });
     expect(response.status).toBe(200);
     const body = (await response.json()) as RegistrationResponse;
@@ -194,11 +195,41 @@ describe("POST /api/registrations/:universityId/:classId", () => {
     const response = await request("/api/registrations/uni1/cls1", "POST", {
       scoutId: "scout1",
       acceptWaitlist: true,
+      acceptConsent: true,
     });
     expect(response.status).toBe(200);
     const body = (await response.json()) as RegistrationResponse;
     expect(body.status).toBe("waitlisted");
     expect(body.waitlistedAt).not.toBeNull();
+  });
+
+  it("maps missing parental consent to 403 consent_required", async () => {
+    const { request } = setup({
+      service: {
+        register: () =>
+          Promise.reject(
+            new ForbiddenError(
+              "Parental consent required",
+              ERROR_CODES.CONSENT_REQUIRED,
+            ),
+          ),
+      },
+    });
+    const response = await request("/api/registrations/uni1/cls1", "POST", {
+      scoutId: "scout1",
+      acceptConsent: false,
+    });
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { code?: string };
+    expect(body.code).toBe(ERROR_CODES.CONSENT_REQUIRED);
+  });
+
+  it("rejects a body missing acceptConsent with 400", async () => {
+    const { request } = setup();
+    const response = await request("/api/registrations/uni1/cls1", "POST", {
+      scoutId: "scout1",
+    });
+    expect(response.status).toBe(400);
   });
 
   it("maps a full class to 409 class_full", async () => {
@@ -216,6 +247,7 @@ describe("POST /api/registrations/:universityId/:classId", () => {
     });
     const response = await request("/api/registrations/uni1/cls1", "POST", {
       scoutId: "scout1",
+      acceptConsent: true,
     });
     expect(response.status).toBe(409);
     const body = (await response.json()) as { code?: string };
@@ -237,6 +269,7 @@ describe("POST /api/registrations/:universityId/:classId", () => {
     });
     const response = await request("/api/registrations/uni1/cls1", "POST", {
       scoutId: "scout1",
+      acceptConsent: true,
     });
     expect(response.status).toBe(409);
     const body = (await response.json()) as {
@@ -261,6 +294,7 @@ describe("POST /api/registrations/:universityId/:classId", () => {
     });
     const response = await request("/api/registrations/uni1/cls1", "POST", {
       scoutId: "scout1",
+      acceptConsent: true,
     });
     expect(response.status).toBe(403);
     const body = (await response.json()) as { code?: string };
@@ -287,7 +321,8 @@ describe("DELETE /api/registrations/:universityId/:classId/:scoutId", () => {
   it("maps a missing registration to 404", async () => {
     const { request } = setup({
       service: {
-        cancel: () => Promise.reject(new NotFoundError("Registration not found")),
+        cancel: () =>
+          Promise.reject(new NotFoundError("Registration not found")),
       },
     });
     const response = await request(
@@ -355,7 +390,8 @@ describe("GET /api/registrations/:universityId/roster", () => {
   it("maps a missing university to 404", async () => {
     const { request } = setup({
       service: {
-        listRoster: () => Promise.reject(new NotFoundError("University not found")),
+        listRoster: () =>
+          Promise.reject(new NotFoundError("University not found")),
       },
     });
     const response = await request("/api/registrations/uni1/roster", "GET");

--- a/functions/src/registrations-api/schemas/registration-schemas.ts
+++ b/functions/src/registrations-api/schemas/registration-schemas.ts
@@ -3,6 +3,7 @@ import { t, type Static } from "elysia";
 export const RegisterRequestSchema = t.Object({
   scoutId: t.String({ minLength: 1 }),
   acceptWaitlist: t.Optional(t.Boolean()),
+  acceptConsent: t.Boolean(),
 });
 export type RegisterRequest = Static<typeof RegisterRequestSchema>;
 

--- a/functions/src/registrations-api/services/registrations/index.test.ts
+++ b/functions/src/registrations-api/services/registrations/index.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "bun:test";
+import { Timestamp, type Firestore } from "firebase-admin/firestore";
+import type { ClassDocument } from "../../../collections/classes.js";
+import type { RegistrationDocument } from "../../../collections/registrations.js";
+import type { ScoutDocument } from "../../../collections/scouts.js";
+import type { UniversityDocument } from "../../../collections/universities.js";
+import { POLICY_VERSION } from "../../../constants/privacy.js";
+import {
+  ERROR_CODES,
+  ForbiddenError,
+} from "../../../shared-api/errors/http-error.js";
+import type { RoleGrantsReader } from "../../../shared-api/services/authz/role-grants-reader.js";
+import type { ScoutOwnershipReader } from "../../../shared-api/services/authz/scout-ownership-reader.js";
+import type { Caller } from "../../../shared-api/types/caller.js";
+import type { Notifier } from "../notifier/interface.js";
+import { RegistrationsServiceImpl } from "./index.js";
+
+const caller: Caller = {
+  uid: "parent1",
+  email: "parent@example.com",
+  emailVerified: true,
+  // Bypasses the registration-window check so the fixture doesn't need real dates.
+  superAdmin: true,
+};
+
+const university: UniversityDocument = {
+  title: "Spring MBU",
+  status: "published",
+  timezone: "America/New_York",
+  startDate: Timestamp.fromDate(new Date("2026-06-01T12:00:00.000Z")),
+  endDate: null,
+  registrationOpensAt: null,
+  registrationClosesAt: Timestamp.fromDate(
+    new Date("2026-05-25T23:59:59.000Z"),
+  ),
+  location: {
+    name: "Scout Hall",
+    address: "1 Main St",
+    city: "Anytown",
+    state: "NY",
+    zip: "12345",
+  },
+  periods: [],
+  createdByUid: "u1",
+  submittedAt: null,
+  publishedAt: null,
+  reviewNote: null,
+  billing: null,
+  createdAt: Timestamp.now(),
+  updatedAt: Timestamp.now(),
+};
+
+const classDoc: ClassDocument = {
+  badgeSlug: "camping",
+  badgeTitle: "Camping",
+  eagleRequired: false,
+  periodIds: ["p1"],
+  capacity: 10,
+  enrolledCount: 0,
+  waitlistCount: 0,
+  room: "Room A",
+  notes: null,
+  counselors: [],
+  createdAt: Timestamp.now(),
+  updatedAt: Timestamp.now(),
+};
+
+const scout: ScoutDocument = {
+  firstName: "Alex",
+  lastName: "Smith",
+  unit: "Troop 1",
+  council: null,
+  district: null,
+  ageBand: "12-13",
+  bsaId: null,
+  accommodations: null,
+  createdAt: Timestamp.now(),
+  updatedAt: Timestamp.now(),
+};
+
+const scoutOwnership: ScoutOwnershipReader = {
+  exists: () => Promise.resolve(true),
+};
+const roleGrants: RoleGrantsReader = {
+  hasActiveGrant: () => Promise.resolve(false),
+  listActiveClassGrants: () => Promise.resolve([]),
+};
+const notifier: Notifier = {
+  registered: () => Promise.resolve(),
+  promoted: () => Promise.resolve(),
+};
+
+function mockFirestore() {
+  let registration: RegistrationDocument | null = null;
+
+  const universityRef = {};
+  const classRef = {};
+  const userRef = {};
+  const registrationRef = {
+    get: () =>
+      Promise.resolve({
+        exists: registration !== null,
+        data: () => registration,
+      }),
+  };
+
+  const scoutRef = {};
+  // `register()` reads this via `txn.get(conflictQuery)`, not `conflictQuery.get()`.
+  const conflictQueryRef = { where: () => conflictQueryRef };
+
+  const db = {
+    collection(path: string) {
+      if (path === "universities") return { doc: () => universityRef };
+      if (path === "users") return { doc: () => userRef };
+      throw new Error(`unexpected collection: ${path}`);
+    },
+    doc(path: string) {
+      if (path.includes("/registrations/")) return registrationRef;
+      if (path.includes("/classes/")) return classRef;
+      if (path.includes("/scouts/")) return scoutRef;
+      throw new Error(`unexpected doc: ${path}`);
+    },
+    collectionGroup() {
+      return conflictQueryRef;
+    },
+    runTransaction(fn: (txn: unknown) => Promise<void>) {
+      const txn = {
+        get(ref: unknown) {
+          if (ref === universityRef) {
+            return Promise.resolve({ exists: true, data: () => university });
+          }
+          if (ref === classRef) {
+            return Promise.resolve({ exists: true, data: () => classDoc });
+          }
+          if (ref === registrationRef) {
+            return Promise.resolve({
+              exists: registration !== null,
+              data: () => registration,
+            });
+          }
+          if (ref === userRef) {
+            return Promise.resolve({ exists: false, data: () => null });
+          }
+          if (ref === scoutRef) {
+            return Promise.resolve({ exists: true, data: () => scout });
+          }
+          if (ref === conflictQueryRef) {
+            return Promise.resolve({ docs: [] });
+          }
+          throw new Error("unexpected txn.get");
+        },
+        set(ref: unknown, data: RegistrationDocument) {
+          if (ref === registrationRef) registration = data;
+        },
+        update() {
+          // Class-count updates aren't asserted on here.
+        },
+      };
+      return fn(txn);
+    },
+  } as unknown as Firestore;
+
+  return { db, getRegistration: () => registration };
+}
+
+describe("RegistrationsServiceImpl.register — consent", () => {
+  it("rejects without writing a registration when acceptConsent is false", async () => {
+    const { db, getRegistration } = mockFirestore();
+    const service = new RegistrationsServiceImpl(
+      db,
+      notifier,
+      scoutOwnership,
+      roleGrants,
+    );
+
+    const attempt = service.register(caller, "uni1", "cls1", {
+      scoutId: "scout1",
+      acceptConsent: false,
+    });
+    await expect(attempt).rejects.toBeInstanceOf(ForbiddenError);
+    await attempt.catch((error: ForbiddenError) => {
+      expect(error.code).toBe(ERROR_CODES.CONSENT_REQUIRED);
+    });
+    expect(getRegistration()).toBeNull();
+  });
+
+  it("stamps acceptedPolicyVersion when the parent consents", async () => {
+    const { db, getRegistration } = mockFirestore();
+    const service = new RegistrationsServiceImpl(
+      db,
+      notifier,
+      scoutOwnership,
+      roleGrants,
+    );
+
+    const result = await service.register(caller, "uni1", "cls1", {
+      scoutId: "scout1",
+      acceptConsent: true,
+    });
+
+    expect(result.status).toBe("enrolled");
+    expect(getRegistration()?.acceptedPolicyVersion).toBe(POLICY_VERSION);
+    expect(getRegistration()?.parentConsentAt).not.toBeNull();
+  });
+});

--- a/functions/src/registrations-api/services/registrations/index.ts
+++ b/functions/src/registrations-api/services/registrations/index.ts
@@ -23,6 +23,7 @@ import {
   USERS_COLLECTION,
   type UserDocument,
 } from "../../../collections/users.js";
+import { POLICY_VERSION } from "../../../constants/privacy.js";
 import {
   ConflictError,
   ERROR_CODES,
@@ -160,6 +161,13 @@ export class RegistrationsServiceImpl implements RegistrationsService {
         priorCreatedAt = existing.createdAt;
       }
 
+      if (request.acceptConsent !== true) {
+        throw new ForbiddenError(
+          "Parental consent required",
+          ERROR_CODES.CONSENT_REQUIRED,
+        );
+      }
+
       const conflictQuery = this.db()
         .collectionGroup(REGISTRATIONS_SUBCOLLECTION)
         .where("scoutId", "==", request.scoutId)
@@ -238,6 +246,7 @@ export class RegistrationsServiceImpl implements RegistrationsService {
         waitlistedAt,
         enrolledAt,
         parentConsentAt: now,
+        acceptedPolicyVersion: POLICY_VERSION,
         createdAt: priorCreatedAt ?? now,
         updatedAt: now,
       };

--- a/functions/src/shared-api/errors/http-error.ts
+++ b/functions/src/shared-api/errors/http-error.ts
@@ -66,6 +66,7 @@ export const ERROR_CODES = {
   EVENT_NOT_OPEN: "event_not_open",
   REGISTRATION_NOT_OPEN: "registration_not_open",
   REGISTRATION_CLOSED: "registration_closed",
+  CONSENT_REQUIRED: "consent_required",
 } as const;
 
 export type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES];

--- a/functions/src/users-api/app.test.ts
+++ b/functions/src/users-api/app.test.ts
@@ -1,5 +1,5 @@
-import type { DecodedIdToken } from "firebase-admin/auth";
 import { describe, expect, it } from "bun:test";
+import type { DecodedIdToken } from "firebase-admin/auth";
 import type { TokenVerifier } from "../shared-api/plugins/require-auth.js";
 import { handleRequest } from "../test-utils/handle-request.js";
 import { createApp } from "./app.js";
@@ -21,7 +21,7 @@ const unverified: TokenVerifier = () =>
   } as DecodedIdToken);
 
 const usersService: UsersService = {
-  bootstrap: (caller) =>
+  bootstrap: caller =>
     Promise.resolve({
       user: {
         uid: caller.uid,
@@ -30,10 +30,11 @@ const usersService: UsersService = {
         phone: null,
         acceptedTermsAt: null,
         acceptedPrivacyAt: null,
+        acceptedPolicyVersion: null,
       },
       needsConsent: true,
     }),
-  getMe: (caller) =>
+  getMe: caller =>
     Promise.resolve({
       uid: caller.uid,
       displayName: "Pat",
@@ -41,6 +42,7 @@ const usersService: UsersService = {
       phone: null,
       acceptedTermsAt: null,
       acceptedPrivacyAt: null,
+      acceptedPolicyVersion: null,
     }),
   onboard: (caller, request) =>
     Promise.resolve({
@@ -50,6 +52,7 @@ const usersService: UsersService = {
       phone: null,
       acceptedTermsAt: "2026-07-03T00:00:00.000Z",
       acceptedPrivacyAt: "2026-07-03T00:00:00.000Z",
+      acceptedPolicyVersion: "2026-07-04",
     }),
 };
 
@@ -101,7 +104,11 @@ describe("users-api auth gate", () => {
   });
 
   it("rejects an unverified email with 403 EMAIL_NOT_VERIFIED", async () => {
-    const app = createApp({ usersService, scoutsService, verifyToken: unverified });
+    const app = createApp({
+      usersService,
+      scoutsService,
+      verifyToken: unverified,
+    });
     const response = await handleRequest(app, authed("/api/users/me", "POST"));
     expect(response.status).toBe(403);
     const body = (await response.json()) as { code?: string };
@@ -114,7 +121,10 @@ describe("users-api routes", () => {
     createApp({ usersService, scoutsService, verifyToken: verified });
 
   it("POST /api/users/me bootstraps and reports needsConsent", async () => {
-    const response = await handleRequest(app(), authed("/api/users/me", "POST"));
+    const response = await handleRequest(
+      app(),
+      authed("/api/users/me", "POST"),
+    );
     expect(response.status).toBe(200);
     const body = (await response.json()) as {
       needsConsent: boolean;

--- a/functions/src/users-api/schemas/user-schemas.ts
+++ b/functions/src/users-api/schemas/user-schemas.ts
@@ -8,6 +8,7 @@ export const UserResponseSchema = t.Object({
   phone: t.Union([t.String(), t.Null()]),
   acceptedTermsAt: t.Union([t.String(), t.Null()]),
   acceptedPrivacyAt: t.Union([t.String(), t.Null()]),
+  acceptedPolicyVersion: t.Union([t.String(), t.Null()]),
 });
 export type UserResponse = Static<typeof UserResponseSchema>;
 

--- a/functions/src/users-api/services/users/index.test.ts
+++ b/functions/src/users-api/services/users/index.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import { Timestamp, type Firestore } from "firebase-admin/firestore";
+import type { UserDocument } from "../../../collections/users.js";
+import { POLICY_VERSION } from "../../../constants/privacy.js";
+import { NotFoundError } from "../../../shared-api/errors/http-error.js";
+import type { Caller } from "../../../shared-api/types/caller.js";
+import { UsersServiceImpl } from "./index.js";
+
+const caller: Caller = {
+  uid: "u1",
+  email: "u1@example.com",
+  emailVerified: true,
+  superAdmin: false,
+};
+
+function mockFirestore(initial: UserDocument | null) {
+  let stored = initial;
+  const ref = {
+    get: () => Promise.resolve({ exists: stored !== null, data: () => stored }),
+    set: (data: Partial<UserDocument>, options?: { merge?: boolean }) => {
+      stored = (
+        options?.merge ? { ...(stored as UserDocument), ...data } : data
+      ) as UserDocument;
+      return Promise.resolve();
+    },
+  };
+  const db = {
+    collection(path: string) {
+      if (path === "users") return { doc: () => ref };
+      throw new Error(`unexpected collection: ${path}`);
+    },
+  } as unknown as Firestore;
+  return { db, getStored: () => stored };
+}
+
+const bootstrapped: UserDocument = {
+  displayName: "",
+  email: caller.email,
+  phone: null,
+  counselorProfile: null,
+  acceptedTermsAt: null,
+  acceptedPrivacyAt: null,
+  acceptedPolicyVersion: null,
+  createdAt: Timestamp.now(),
+  updatedAt: Timestamp.now(),
+};
+
+describe("UsersServiceImpl.onboard", () => {
+  it("stamps acceptedPolicyVersion alongside the terms/privacy timestamps", async () => {
+    const { db, getStored } = mockFirestore(bootstrapped);
+    const service = new UsersServiceImpl(db);
+
+    const result = await service.onboard(caller, {
+      displayName: "Pat Parent",
+      acceptedTerms: true,
+    });
+
+    expect(result.displayName).toBe("Pat Parent");
+    expect(getStored()?.acceptedPolicyVersion).toBe(POLICY_VERSION);
+  });
+
+  it("throws NotFoundError when the user hasn't bootstrapped", async () => {
+    const { db } = mockFirestore(null);
+    const service = new UsersServiceImpl(db);
+
+    await expect(
+      service.onboard(caller, { displayName: "Pat", acceptedTerms: true }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+});

--- a/functions/src/users-api/services/users/index.ts
+++ b/functions/src/users-api/services/users/index.ts
@@ -1,6 +1,15 @@
-import { FieldValue, getFirestore, Timestamp } from "firebase-admin/firestore";
+import {
+  FieldValue,
+  getFirestore,
+  Timestamp,
+  type Firestore,
+} from "firebase-admin/firestore";
 import { ROLE_GRANTS_COLLECTION } from "../../../collections/role-grants.js";
-import { USERS_COLLECTION, type UserDocument } from "../../../collections/users.js";
+import {
+  USERS_COLLECTION,
+  type UserDocument,
+} from "../../../collections/users.js";
+import { POLICY_VERSION } from "../../../constants/privacy.js";
 import { NotFoundError } from "../../../shared-api/errors/http-error.js";
 import type { Caller } from "../../../shared-api/types/caller.js";
 import type {
@@ -22,13 +31,19 @@ function toUserResponse(uid: string, doc: UserDocument): UserResponse {
     phone: doc.phone,
     acceptedTermsAt: toIso(doc.acceptedTermsAt),
     acceptedPrivacyAt: toIso(doc.acceptedPrivacyAt),
+    acceptedPolicyVersion: doc.acceptedPolicyVersion,
   };
 }
 
 export class UsersServiceImpl implements UsersService {
+  constructor(private readonly database?: Firestore) {}
+
+  private db(): Firestore {
+    return this.database ?? getFirestore();
+  }
+
   async bootstrap(caller: Caller): Promise<BootstrapResponse> {
-    const database = getFirestore();
-    const reference = database.collection(USERS_COLLECTION).doc(caller.uid);
+    const reference = this.db().collection(USERS_COLLECTION).doc(caller.uid);
     const existing = await reference.get();
 
     if (existing.exists) {
@@ -46,6 +61,7 @@ export class UsersServiceImpl implements UsersService {
         counselorProfile: null,
         acceptedTermsAt: null,
         acceptedPrivacyAt: null,
+        acceptedPolicyVersion: null,
         createdAt: FieldValue.serverTimestamp(),
         updatedAt: FieldValue.serverTimestamp(),
       });
@@ -62,7 +78,7 @@ export class UsersServiceImpl implements UsersService {
   }
 
   async getMe(caller: Caller): Promise<UserResponse> {
-    const snapshot = await getFirestore()
+    const snapshot = await this.db()
       .collection(USERS_COLLECTION)
       .doc(caller.uid)
       .get();
@@ -76,9 +92,7 @@ export class UsersServiceImpl implements UsersService {
     caller: Caller,
     request: OnboardingRequest,
   ): Promise<UserResponse> {
-    const reference = getFirestore()
-      .collection(USERS_COLLECTION)
-      .doc(caller.uid);
+    const reference = this.db().collection(USERS_COLLECTION).doc(caller.uid);
     if (!(await reference.get()).exists) {
       throw new NotFoundError("User not found; bootstrap the session first");
     }
@@ -87,6 +101,7 @@ export class UsersServiceImpl implements UsersService {
         displayName: request.displayName,
         acceptedTermsAt: FieldValue.serverTimestamp(),
         acceptedPrivacyAt: FieldValue.serverTimestamp(),
+        acceptedPolicyVersion: POLICY_VERSION,
         updatedAt: FieldValue.serverTimestamp(),
       },
       { merge: true },
@@ -103,7 +118,7 @@ export class UsersServiceImpl implements UsersService {
    * match the stored invitedEmail.
    */
   private async claimPendingInvites(caller: Caller): Promise<void> {
-    const database = getFirestore();
+    const database = this.db();
     const pending = await database
       .collection(ROLE_GRANTS_COLLECTION)
       .where("invitedEmail", "==", caller.email)

--- a/functions/src/users-api/services/users/index.ts
+++ b/functions/src/users-api/services/users/index.ts
@@ -31,7 +31,7 @@ function toUserResponse(uid: string, doc: UserDocument): UserResponse {
     phone: doc.phone,
     acceptedTermsAt: toIso(doc.acceptedTermsAt),
     acceptedPrivacyAt: toIso(doc.acceptedPrivacyAt),
-    acceptedPolicyVersion: doc.acceptedPolicyVersion,
+    acceptedPolicyVersion: doc.acceptedPolicyVersion ?? null,
   };
 }
 


### PR DESCRIPTION
## Summary
- PR 1 of the youth-data-privacy plan (issue #88). Replaces the auto-stamped `parentConsentAt` (always "Yes" on the roster) with an explicit parental act.
- Registration now requires `acceptConsent: true` in the request body; the service guards on it before stamping and writes `acceptedPolicyVersion` (new `POLICY_VERSION` constant) alongside `parentConsentAt`.
- Onboarding acceptance also stamps `acceptedPolicyVersion`.
- Register page adds a per-event consent checkbox; Register/Join-waitlist/Drop are disabled until it's checked.
- Adds `/privacy` and `/terms` route stubs (placeholder content) for #115 to fill in with real policy prose; onboarding's "Terms and Privacy Policy" label now links to them.

Out of scope (deferred to #115 or later per the plan): policy/ToS prose, re-consent-on-version-bump.

## Test plan
- [x] `cd functions && bun test` — 131 pass, including new `RegistrationsServiceImpl.register` consent unit tests (Pattern B fake Firestore) and `UsersServiceImpl.onboard` unit tests
- [x] `cd app && bun run test` — 60 pass, including new register.spec.ts coverage for checkbox rendering and button disabling
- [x] `tsc --noEmit` clean in both `functions` and `app`
- [x] `eslint` clean on changed frontend files
- [ ] Manual/emulator smoke test not performed — no local Auth+Firestore emulator seed harness exists in this repo to drive a full register flow end-to-end; verified via component tests exercising real Angular change detection instead