### PR TITLE
Add post-event retention purge — issue #88

### DIFF
--- a/.github/workflows/retention-purge-cron.yml
+++ b/.github/workflows/retention-purge-cron.yml
@@ -1,0 +1,25 @@
+name: Retention purge cron
+
+on:
+  schedule:
+    # Daily — the purge itself is idempotent and only acts on universities
+    # whose event ended 90+ days ago, so running more often than needed is
+    # harmless. Off-peak, off-the-hour to avoid GitHub Actions' cron pile-up.
+    - cron: "23 9 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  purge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call the retention purge endpoint
+        run: |
+          status=$(curl -sS -o /tmp/response.json -w "%{http_code}" \
+            -X POST "https://mbu-platform.web.app/api/retention/purge" \
+            -H "Authorization: Bearer ${{ secrets.RETENTION_PURGE_SECRET }}")
+          echo "HTTP status: $status"
+          cat /tmp/response.json
+          if [ "$status" -ge 300 ]; then
+            echo "Retention purge request failed"
+            exit 1
+          fi

--- a/app/src/app/api-types/registrations-api.types.ts
+++ b/app/src/app/api-types/registrations-api.types.ts
@@ -24,12 +24,13 @@ export interface ScheduleResponse {
 
 export interface RosterRow {
   scoutId: string;
-  scoutFirstName: string;
-  scoutLastName: string;
+  /** Null once the retention purge scrubs this registration's PII snapshot. */
+  scoutFirstName: string | null;
+  scoutLastName: string | null;
   scoutUnit: string | null;
   accommodations: string | null;
-  parentName: string;
-  parentEmail: string;
+  parentName: string | null;
+  parentEmail: string | null;
   consentReceived: boolean;
   status: RegistrationStatus;
 }

--- a/app/src/app/lib/roster-csv.ts
+++ b/app/src/app/lib/roster-csv.ts
@@ -18,14 +18,14 @@ function csvRow(fields: string[]): string {
 function rosterRowFields(row: RosterRow, waitlistPosition: string): string[] {
   return [
     '', // Present
-    row.scoutLastName,
-    row.scoutFirstName,
+    row.scoutLastName ?? '',
+    row.scoutFirstName ?? '',
     row.scoutUnit ?? '',
     row.status,
     waitlistPosition,
     row.accommodations ?? '',
-    row.parentName,
-    row.parentEmail,
+    row.parentName ?? '',
+    row.parentEmail ?? '',
     row.consentReceived ? 'Yes' : 'No',
   ];
 }

--- a/app/src/app/universities/roster-page/roster-page.html
+++ b/app/src/app/universities/roster-page/roster-page.html
@@ -38,11 +38,15 @@
         </header>
 
         @if (classRoster.class.counselorNames.length > 0) {
-          <p class="roster-page__counselors">Counselors: {{ classRoster.class.counselorNames.join(', ') }}</p>
+          <p class="roster-page__counselors">
+            Counselors: {{ classRoster.class.counselorNames.join(', ') }}
+          </p>
         }
 
         <table class="roster-page__table">
-          <caption>Enrolled</caption>
+          <caption>
+            Enrolled
+          </caption>
           <thead>
             <tr>
               <th scope="col">Present</th>
@@ -58,11 +62,17 @@
             @for (row of classRoster.enrolled; track row.scoutId) {
               <tr>
                 <td></td>
-                <td>{{ row.scoutLastName }}</td>
-                <td>{{ row.scoutFirstName }}</td>
+                <td>{{ row.scoutLastName ?? '(purged)' }}</td>
+                <td>{{ row.scoutFirstName ?? '(purged)' }}</td>
                 <td>{{ row.scoutUnit ?? '—' }}</td>
                 <td>{{ row.accommodations ?? '—' }}</td>
-                <td>{{ row.parentName }} ({{ row.parentEmail }})</td>
+                <td>
+                  @if (row.parentName || row.parentEmail) {
+                    {{ row.parentName }} ({{ row.parentEmail }})
+                  } @else {
+                    (purged)
+                  }
+                </td>
                 <td>{{ row.consentReceived ? 'Yes' : 'No' }}</td>
               </tr>
             } @empty {
@@ -75,7 +85,9 @@
 
         @if (classRoster.waitlisted.length > 0) {
           <table class="roster-page__table">
-            <caption>Waitlisted</caption>
+            <caption>
+              Waitlisted
+            </caption>
             <thead>
               <tr>
                 <th scope="col">Position</th>
@@ -91,11 +103,17 @@
               @for (row of classRoster.waitlisted; track row.scoutId; let i = $index) {
                 <tr>
                   <td>{{ i + 1 }}</td>
-                  <td>{{ row.scoutLastName }}</td>
-                  <td>{{ row.scoutFirstName }}</td>
+                  <td>{{ row.scoutLastName ?? '(purged)' }}</td>
+                  <td>{{ row.scoutFirstName ?? '(purged)' }}</td>
                   <td>{{ row.scoutUnit ?? '—' }}</td>
                   <td>{{ row.accommodations ?? '—' }}</td>
-                  <td>{{ row.parentName }} ({{ row.parentEmail }})</td>
+                  <td>
+                    @if (row.parentName || row.parentEmail) {
+                      {{ row.parentName }} ({{ row.parentEmail }})
+                    } @else {
+                      (purged)
+                    }
+                  </td>
                   <td>{{ row.consentReceived ? 'Yes' : 'No' }}</td>
                 </tr>
               }

--- a/firebase.json
+++ b/firebase.json
@@ -118,6 +118,11 @@
           "region": "us-east4"
         },
         {
+          "source": "/api/retention{,/**}",
+          "function": "retentionApi",
+          "region": "us-east4"
+        },
+        {
           "source": "**",
           "destination": "/index.html"
         }

--- a/functions/src/collections/registrations.ts
+++ b/functions/src/collections/registrations.ts
@@ -19,8 +19,10 @@ export type RegistrationStatus = "enrolled" | "waitlisted" | "cancelled";
 
 /**
  * A scout's seat hold in a class. Soft-deleted (status: 'cancelled'), not hard-deleted
- * until post-event purge. Denormalized fields are snapshots kept fresh by bounded
- * re-sync on the parent edit paths (no Firestore triggers).
+ * until a scout/account deletion cascade. Denormalized fields are snapshots kept fresh
+ * by bounded re-sync on the parent edit paths (no Firestore triggers). 90 days past the
+ * event's effective end, the retention purge nulls the PII snapshot fields below (but
+ * keeps the doc — see `purgedAt`) for #89 advancement proof.
  */
 export interface RegistrationDocument {
   /** Equals the document id. */
@@ -33,15 +35,16 @@ export interface RegistrationDocument {
   periodIds: string[];
   badgeSlug: string;
   badgeTitle: string;
-  // Scout snapshot for the roster.
-  scoutFirstName: string;
-  scoutLastName: string;
+  // Scout snapshot for the roster. Nulled by the retention purge.
+  scoutFirstName: string | null;
+  scoutLastName: string | null;
   scoutUnit: string | null;
   /** Visible to this class's counselor/chancellor via API-restricted roster reads. */
   accommodations: string | null;
-  // Parent contact snapshot. parentEmail is display-only; delivery resolves the live user doc.
-  parentName: string;
-  parentEmail: string;
+  // Parent contact snapshot. parentEmail is display-only; delivery resolves the live
+  // user doc. Nulled by the retention purge.
+  parentName: string | null;
+  parentEmail: string | null;
   status: RegistrationStatus;
   /** Set iff waitlisted; drives promotion ordering (position is derived, not stored). */
   waitlistedAt: Timestamp | null;
@@ -49,6 +52,8 @@ export interface RegistrationDocument {
   parentConsentAt: Timestamp | null;
   /** POLICY_VERSION in effect when parentConsentAt was stamped. */
   acceptedPolicyVersion: string | null;
+  /** Set once the retention purge has nulled this doc's PII fields; idempotency marker. */
+  purgedAt: Timestamp | null;
   createdAt: Timestamp;
   updatedAt: Timestamp;
 }

--- a/functions/src/constants/retention.ts
+++ b/functions/src/constants/retention.ts
@@ -1,0 +1,2 @@
+/** Days past an event's effective end before the retention purge scrubs registration PII. */
+export const RETENTION_WINDOW_DAYS = 90;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -7,6 +7,7 @@ if (getApps().length === 0) {
 }
 
 const MAILGUN_API_KEY = defineSecret("MAILGUN_API_KEY");
+const RETENTION_PURGE_SECRET = defineSecret("RETENTION_PURGE_SECRET");
 
 export const healthApi = onRequest(
   {
@@ -52,5 +53,20 @@ export const registrationsApi = onRequest(
     const { handleRegistrationsApi } =
       await import("./registrations-api/handler.js");
     await handleRegistrationsApi(request, response);
+  },
+);
+
+// Invoker is "public" (network-reachable by anyone) like the other APIs, but
+// the only real caller is the daily GitHub Actions cron job — app-level auth
+// is the shared secret checked by requireCronSecret, not a Firebase ID token.
+export const retentionApi = onRequest(
+  {
+    invoker: "public",
+    region: "us-east4",
+    secrets: [RETENTION_PURGE_SECRET],
+  },
+  async (request, response) => {
+    const { handleRetentionApi } = await import("./retention-api/handler.js");
+    await handleRetentionApi(request, response);
   },
 );

--- a/functions/src/registrations-api/schemas/registration-schemas.ts
+++ b/functions/src/registrations-api/schemas/registration-schemas.ts
@@ -27,12 +27,13 @@ export type ScheduleResponse = Static<typeof ScheduleResponseSchema>;
 
 export const RosterRowSchema = t.Object({
   scoutId: t.String(),
-  scoutFirstName: t.String(),
-  scoutLastName: t.String(),
+  // Nulled once the retention purge scrubs this registration's PII snapshot.
+  scoutFirstName: t.Union([t.String(), t.Null()]),
+  scoutLastName: t.Union([t.String(), t.Null()]),
   scoutUnit: t.Union([t.String(), t.Null()]),
   accommodations: t.Union([t.String(), t.Null()]),
-  parentName: t.String(),
-  parentEmail: t.String(),
+  parentName: t.Union([t.String(), t.Null()]),
+  parentEmail: t.Union([t.String(), t.Null()]),
   consentReceived: t.Boolean(),
   status: t.Union([t.Literal("enrolled"), t.Literal("waitlisted")]),
 });

--- a/functions/src/registrations-api/services/registrations/index.ts
+++ b/functions/src/registrations-api/services/registrations/index.ts
@@ -247,6 +247,7 @@ export class RegistrationsServiceImpl implements RegistrationsService {
         enrolledAt,
         parentConsentAt: now,
         acceptedPolicyVersion: POLICY_VERSION,
+        purgedAt: null,
         createdAt: priorCreatedAt ?? now,
         updatedAt: now,
       };
@@ -464,8 +465,8 @@ export class RegistrationsServiceImpl implements RegistrationsService {
         .filter(row => row.status === "enrolled")
         .sort((a, b) =>
           a.scoutLastName === b.scoutLastName
-            ? a.scoutFirstName.localeCompare(b.scoutFirstName)
-            : a.scoutLastName.localeCompare(b.scoutLastName),
+            ? (a.scoutFirstName ?? "").localeCompare(b.scoutFirstName ?? "")
+            : (a.scoutLastName ?? "").localeCompare(b.scoutLastName ?? ""),
         )
         .map(toRosterRow);
       const waitlisted = rows

--- a/functions/src/retention-api/app.test.ts
+++ b/functions/src/retention-api/app.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import { handleRequest } from "../test-utils/handle-request.js";
+import { createApp } from "./app.js";
+import type { SecretReader } from "./plugins/require-cron-secret.js";
+import type { RetentionService } from "./services/retention/interface.js";
+
+interface SetupOptions {
+  /** Bearer header value; `null` sends no Authorization header. */
+  authHeader?: string | null;
+  /** Cron secret the app is configured to expect; `null` means unconfigured. */
+  configuredSecret?: string | null;
+  service?: Partial<RetentionService>;
+}
+
+function setup({
+  authHeader = "Bearer test-secret",
+  configuredSecret = "test-secret",
+  service = {},
+}: SetupOptions = {}) {
+  const secretReader: SecretReader = () => configuredSecret ?? undefined;
+
+  const retentionService: RetentionService = {
+    purge: () =>
+      Promise.resolve({ universitiesProcessed: 0, registrationsPurged: 0 }),
+    ...service,
+  };
+
+  const app = createApp({ retentionService, secretReader });
+
+  function request() {
+    const headers: Record<string, string> = {};
+    if (authHeader) headers["authorization"] = authHeader;
+    return handleRequest(
+      app,
+      new Request("http://localhost/api/retention/purge", {
+        method: "POST",
+        headers,
+      }),
+    );
+  }
+
+  return { request };
+}
+
+describe("POST /api/retention/purge", () => {
+  it("rejects a request with no Authorization header (401)", async () => {
+    const { request } = setup({ authHeader: null });
+    const response = await request();
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects a request with the wrong secret (401)", async () => {
+    const { request } = setup({ authHeader: "Bearer wrong-secret" });
+    const response = await request();
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects every request when no secret is configured", async () => {
+    const { request } = setup({ configuredSecret: null });
+    const response = await request();
+    expect(response.status).toBe(401);
+  });
+
+  it("runs the purge and returns its counts with the correct secret", async () => {
+    const { request } = setup({
+      service: {
+        purge: () =>
+          Promise.resolve({ universitiesProcessed: 2, registrationsPurged: 5 }),
+      },
+    });
+    const response = await request();
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      universitiesProcessed: number;
+      registrationsPurged: number;
+    };
+    expect(body).toEqual({ universitiesProcessed: 2, registrationsPurged: 5 });
+  });
+});

--- a/functions/src/retention-api/app.ts
+++ b/functions/src/retention-api/app.ts
@@ -1,0 +1,29 @@
+import { node } from "@elysiajs/node";
+import { Elysia } from "elysia";
+import { mapError } from "../shared-api/errors/on-error.js";
+import { requireCronSecret } from "./plugins/require-cron-secret.js";
+import { PurgeResponseSchema } from "./schemas/retention-schemas.js";
+import { retentionService as defaultRetention } from "./services/retention/index.js";
+import type { PartialRetentionApiServices } from "./types/services.js";
+
+/**
+ * Create the retention-api Elysia app with injectable dependencies.
+ *
+ * Firebase hosting routes /api/retention/** → retentionApi function. Called
+ * only by the daily GitHub Actions cron job (see
+ * .github/workflows/retention-purge-cron.yml) — authenticated by a shared
+ * secret (requireCronSecret), not a Firebase ID token, since the caller
+ * isn't a signed-in user.
+ */
+export function createApp(services?: PartialRetentionApiServices) {
+  const retention = services?.retentionService ?? defaultRetention;
+
+  return new Elysia({ adapter: node(), prefix: "/api" })
+    .onError(mapError)
+    .resolve(requireCronSecret(services?.secretReader))
+    .post("/retention/purge", () => retention.purge(), {
+      response: PurgeResponseSchema,
+    });
+}
+
+export const app = createApp();

--- a/functions/src/retention-api/handler.ts
+++ b/functions/src/retention-api/handler.ts
@@ -1,0 +1,20 @@
+import { logger as firebaseLogger } from "firebase-functions/v2";
+import type { Request } from "firebase-functions/v2/https";
+import type { FirebaseResponse } from "../shared-api/types/firebase-response.js";
+import type { Logger } from "../shared-api/types/logger.js";
+import { handleElysiaRequest } from "../shared-api/utils/handle-elysia-request.js";
+
+export async function handleRetentionApi(
+  request: Request,
+  response: FirebaseResponse,
+  logger: Logger = firebaseLogger,
+): Promise<void> {
+  const { app } = await import("./app.js");
+  return handleElysiaRequest({
+    app,
+    request,
+    response,
+    logger,
+    apiName: "retention-api",
+  });
+}

--- a/functions/src/retention-api/plugins/require-cron-secret.ts
+++ b/functions/src/retention-api/plugins/require-cron-secret.ts
@@ -1,0 +1,31 @@
+import { AuthError } from "../../shared-api/errors/http-error.js";
+
+/** Reads the configured cron secret. Injected so tests don't need real env vars. */
+export type SecretReader = () => string | undefined;
+
+/** Live reader — bound into process.env by the `secrets` list on the retentionApi function. */
+export const cronSecretReader: SecretReader = () =>
+  process.env["RETENTION_PURGE_SECRET"];
+
+/**
+ * Elysia `resolve` handler factory authenticating the GitHub Actions cron
+ * caller — there's no Firebase user to sign in as, so this checks a shared
+ * secret (`Authorization: Bearer <secret>`) instead of the ID-token check
+ * `requireAuth` does for the other APIs. Fails closed: an unconfigured
+ * secret rejects every request rather than accepting none.
+ */
+export function requireCronSecret(
+  secretReader: SecretReader = cronSecretReader,
+) {
+  return ({
+    headers,
+  }: {
+    headers: Record<string, string | undefined>;
+  }): void => {
+    const expected = secretReader();
+    const provided = headers["authorization"];
+    if (!expected || provided !== `Bearer ${expected}`) {
+      throw new AuthError("Invalid or missing cron secret");
+    }
+  };
+}

--- a/functions/src/retention-api/schemas/retention-schemas.ts
+++ b/functions/src/retention-api/schemas/retention-schemas.ts
@@ -1,0 +1,7 @@
+import { t, type Static } from "elysia";
+
+export const PurgeResponseSchema = t.Object({
+  universitiesProcessed: t.Number(),
+  registrationsPurged: t.Number(),
+});
+export type PurgeResponse = Static<typeof PurgeResponseSchema>;

--- a/functions/src/retention-api/services/retention/index.ts
+++ b/functions/src/retention-api/services/retention/index.ts
@@ -1,0 +1,93 @@
+import {
+  getFirestore,
+  Timestamp,
+  type Firestore,
+} from "firebase-admin/firestore";
+import {
+  REGISTRATIONS_SUBCOLLECTION,
+  type RegistrationDocument,
+} from "../../../collections/registrations.js";
+import {
+  UNIVERSITIES_COLLECTION,
+  type UniversityDocument,
+} from "../../../collections/universities.js";
+import { RETENTION_WINDOW_DAYS } from "../../../constants/retention.js";
+import type { PurgeResponse } from "../../schemas/retention-schemas.js";
+import type { RetentionService } from "./interface.js";
+
+const RETENTION_WINDOW_MS = RETENTION_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+
+export class RetentionServiceImpl implements RetentionService {
+  constructor(private readonly database?: Firestore) {}
+
+  private db(): Firestore {
+    return this.database ?? getFirestore();
+  }
+
+  async purge(): Promise<PurgeResponse> {
+    const cutoff = Timestamp.fromMillis(Date.now() - RETENTION_WINDOW_MS);
+
+    // endDate is null for single-day events, in which case startDate is the
+    // effective end; endDate is otherwise always >= startDate. So "startDate
+    // < cutoff" is a safe superset — every university whose effective end
+    // precedes the cutoff also has startDate before it — filtered precisely
+    // in memory below (Firestore can't query a `COALESCE`-style OR).
+    const candidates = await this.db()
+      .collection(UNIVERSITIES_COLLECTION)
+      .where("startDate", "<", cutoff)
+      .get();
+
+    let universitiesProcessed = 0;
+    let registrationsPurged = 0;
+
+    for (const doc of candidates.docs) {
+      const university = doc.data() as UniversityDocument;
+      const effectiveEnd = university.endDate ?? university.startDate;
+      if (effectiveEnd.toMillis() >= cutoff.toMillis()) continue;
+
+      universitiesProcessed += 1;
+      registrationsPurged += await this.purgeUniversity(doc.id);
+    }
+
+    return { universitiesProcessed, registrationsPurged };
+  }
+
+  private async purgeUniversity(universityId: string): Promise<number> {
+    const pending = await this.db()
+      .collectionGroup(REGISTRATIONS_SUBCOLLECTION)
+      .where("universityId", "==", universityId)
+      .where("purgedAt", "==", null)
+      .get();
+
+    if (pending.empty) return 0;
+
+    const batch = this.db().batch();
+    const purgedAt = Timestamp.now();
+    const scrubbedFields: Pick<
+      RegistrationDocument,
+      | "scoutFirstName"
+      | "scoutLastName"
+      | "scoutUnit"
+      | "accommodations"
+      | "parentName"
+      | "parentEmail"
+      | "purgedAt"
+    > = {
+      scoutFirstName: null,
+      scoutLastName: null,
+      scoutUnit: null,
+      accommodations: null,
+      parentName: null,
+      parentEmail: null,
+      purgedAt,
+    };
+    for (const doc of pending.docs) {
+      batch.update(doc.ref, scrubbedFields);
+    }
+    await batch.commit();
+
+    return pending.size;
+  }
+}
+
+export const retentionService: RetentionService = new RetentionServiceImpl();

--- a/functions/src/retention-api/services/retention/index.ts
+++ b/functions/src/retention-api/services/retention/index.ts
@@ -17,6 +17,9 @@ import type { RetentionService } from "./interface.js";
 
 const RETENTION_WINDOW_MS = RETENTION_WINDOW_DAYS * 24 * 60 * 60 * 1000;
 
+/** Firestore's hard limit on operations in a single batched write. */
+const MAX_BATCH_WRITES = 500;
+
 export class RetentionServiceImpl implements RetentionService {
   constructor(private readonly database?: Firestore) {}
 
@@ -61,7 +64,6 @@ export class RetentionServiceImpl implements RetentionService {
 
     if (pending.empty) return 0;
 
-    const batch = this.db().batch();
     const purgedAt = Timestamp.now();
     const scrubbedFields: Pick<
       RegistrationDocument,
@@ -81,10 +83,17 @@ export class RetentionServiceImpl implements RetentionService {
       parentEmail: null,
       purgedAt,
     };
-    for (const doc of pending.docs) {
-      batch.update(doc.ref, scrubbedFields);
+    // Firestore caps a batched write at 500 operations; a large event can have
+    // more registrations than that, so commit in chunks. The purgedAt filter
+    // above keeps this idempotent even if a later chunk fails and the job
+    // re-runs — already-scrubbed docs drop out of the query.
+    for (let i = 0; i < pending.docs.length; i += MAX_BATCH_WRITES) {
+      const batch = this.db().batch();
+      for (const doc of pending.docs.slice(i, i + MAX_BATCH_WRITES)) {
+        batch.update(doc.ref, scrubbedFields);
+      }
+      await batch.commit();
     }
-    await batch.commit();
 
     return pending.size;
   }

--- a/functions/src/retention-api/services/retention/interface.ts
+++ b/functions/src/retention-api/services/retention/interface.ts
@@ -1,0 +1,10 @@
+import type { PurgeResponse } from "../../schemas/retention-schemas.js";
+
+export interface RetentionService {
+  /**
+   * Nulls the PII snapshot on every not-yet-purged registration belonging to
+   * a university whose effective end (`endDate ?? startDate`) is 90+ days in
+   * the past. Idempotent — safe to run daily.
+   */
+  purge(): Promise<PurgeResponse>;
+}

--- a/functions/src/retention-api/types/services.ts
+++ b/functions/src/retention-api/types/services.ts
@@ -1,0 +1,14 @@
+import type { SecretReader } from "../plugins/require-cron-secret.js";
+import type { RetentionService } from "../services/retention/interface.js";
+
+/**
+ * Injectable dependencies for the retention-api app. Tests override any
+ * subset; production uses the live defaults wired in app.ts.
+ */
+export interface RetentionApiServices {
+  retentionService: RetentionService;
+  /** Cron-secret reader used by the requireCronSecret resolver (fakeable in tests). */
+  secretReader: SecretReader;
+}
+
+export type PartialRetentionApiServices = Partial<RetentionApiServices>;


### PR DESCRIPTION
## Summary
- PR 3 of the youth-data-privacy plan (issue #88). 90 days past an event's effective end (`endDate ?? startDate`), scrubs the PII snapshot on every registration while preserving a non-PII skeleton (`scoutId`, `universityId`, `classId`, `badgeSlug`, `status`, `enrolledAt`) for #89 advancement proof. Idempotent via a `purgedAt` marker.
- **Architecture change from the original plan**: instead of a Firebase `onSchedule` Cloud Function (which needs Cloud Scheduler enabled on the project — a deploy-time risk the plan itself flagged), this ships as a plain HTTP endpoint (`POST /api/retention/purge`) called by a daily GitHub Actions cron job. Two benefits: no new GCP dependency, and it fits the existing Elysia HTTP API pattern instead of inventing an untested "scheduled function" shape this codebase has no precedent for.
- New `retention-api` (same shape as the other four APIs: `app.ts`/`handler.ts`/`services/`). Since the caller is GHA, not a signed-in Firebase user, auth is a shared secret (`RETENTION_PURGE_SECRET`, same `defineSecret` pattern as `MAILGUN_API_KEY`) checked by a new `requireCronSecret` resolver instead of the ID-token `requireAuth` gate.
- Widens `scoutFirstName`/`scoutLastName`/`parentName`/`parentEmail` on `RegistrationDocument` (and the roster API/frontend types) to `string | null`; the roster UI and CSV export now show `(purged)` for scrubbed rows.
- Per the repo's `testing-philosophy.md` ("don't test the service layer directly"), `RetentionServiceImpl`'s internal 90-day-boundary/nulling/idempotency logic is **not** unit-tested directly — only the HTTP boundary (auth + mocked-service response mapping) is, matching every other API in this codebase.

## Test plan
- [x] `cd functions && bun test` — 135 pass, including new `retention-api/app.test.ts` (missing/wrong/unconfigured secret → 401, correct secret → 200 with purge counts)
- [x] `cd app && bun run test` — 61 pass
- [x] `tsc --noEmit` clean in both `functions` and `app`
- [x] `eslint` clean on changed frontend files
- [ ] Manual/emulator smoke test not performed (same limitation as PR1/PR2 — no seed harness in this repo). Before merge, worth manually confirming against a real/emulated Firestore: a university with effective end > 90 days ago has its registrations' PII nulled with `purgedAt` set, a second run is a no-op, and the roster skeleton (`scoutId`, `status`, etc.) survives.
- [ ] Needs a `RETENTION_PURGE_SECRET` value set as both a Firebase secret (`firebase functions:secrets:set RETENTION_PURGE_SECRET`) and a GitHub Actions repo secret before the cron job can run for real.