### PR TITLE
Add roster-export accountability + authz negative-case coverage — issue #88

### DIFF
--- a/app/src/app/api-types/users-api.types.ts
+++ b/app/src/app/api-types/users-api.types.ts
@@ -9,6 +9,7 @@ export interface UserResponse {
   acceptedTermsAt: string | null;
   acceptedPrivacyAt: string | null;
   acceptedPolicyVersion: string | null;
+  rosterExportAckAt: string | null;
 }
 
 /** Bootstrap result: the user doc plus whether onboarding/consent is still required. */

--- a/app/src/app/guards/auth-guards.spec.ts
+++ b/app/src/app/guards/auth-guards.spec.ts
@@ -183,6 +183,7 @@ function fakeUser() {
     acceptedTermsAt: null,
     acceptedPrivacyAt: null,
     acceptedPolicyVersion: null,
+    rosterExportAckAt: null,
   };
 }
 

--- a/app/src/app/services/auth.ts
+++ b/app/src/app/services/auth.ts
@@ -14,7 +14,7 @@ import {
   type UserCredential,
 } from 'firebase/auth';
 import { firstValueFrom } from 'rxjs';
-import type { BootstrapResponse } from '../api-types/users-api.types';
+import type { BootstrapResponse, UserResponse } from '../api-types/users-api.types';
 import { auth } from '../lib/firebase';
 
 // Shared auth error messages, translated from Firebase error codes.
@@ -180,6 +180,18 @@ export class Auth {
   async deleteAccount(): Promise<void> {
     await firstValueFrom(this.httpClient.delete('/api/users/me'));
     await this.signOut();
+  }
+
+  /**
+   * Stamps the one-time roster-export acknowledgment and updates the cached
+   * session user in place, so `sessionUser()` reflects it immediately without
+   * a re-bootstrap.
+   */
+  async ackRosterExport(): Promise<void> {
+    const user = await firstValueFrom(
+      this.httpClient.post<UserResponse>('/api/users/me/roster-export-ack', {}),
+    );
+    this.session.value.update((current) => (current ? { ...current, user } : current));
   }
 
   async signOut(): Promise<void> {

--- a/app/src/app/shared/confirm-modal/confirm-modal.css
+++ b/app/src/app/shared/confirm-modal/confirm-modal.css
@@ -1,0 +1,24 @@
+:host {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(0 0 0 / 50%);
+  z-index: 100;
+}
+
+.confirm-modal__dialog {
+  max-width: 28rem;
+  padding: 1.5rem;
+  border-radius: 0.5rem;
+  background: var(--color-surface);
+  box-shadow: 0 0.5rem 1.5rem rgb(0 0 0 / 25%);
+}
+
+.confirm-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}

--- a/app/src/app/shared/confirm-modal/confirm-modal.html
+++ b/app/src/app/shared/confirm-modal/confirm-modal.html
@@ -1,0 +1,16 @@
+<div
+  class="confirm-modal__dialog"
+  role="alertdialog"
+  aria-modal="true"
+  [attr.aria-label]="title() || message()"
+  (click)="$event.stopPropagation()"
+>
+  @if (title()) {
+    <h2>{{ title() }}</h2>
+  }
+  <p>{{ message() }}</p>
+  <div class="confirm-modal__actions">
+    <button type="button" (click)="cancelled.emit()">{{ cancelLabel() }}</button>
+    <button type="button" (click)="confirmed.emit()">{{ confirmLabel() }}</button>
+  </div>
+</div>

--- a/app/src/app/shared/confirm-modal/confirm-modal.ts
+++ b/app/src/app/shared/confirm-modal/confirm-modal.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+
+/** Generic confirm/cancel dialog. The parent owns visibility via @if. */
+@Component({
+  selector: 'app-confirm-modal',
+  templateUrl: './confirm-modal.html',
+  styleUrl: './confirm-modal.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { '(click)': 'cancelled.emit()' },
+})
+export class ConfirmModal {
+  readonly title = input('');
+  readonly message = input.required<string>();
+  readonly confirmLabel = input('Continue');
+  readonly cancelLabel = input('Cancel');
+
+  readonly confirmed = output<void>();
+  readonly cancelled = output<void>();
+}

--- a/app/src/app/universities/roster-page/roster-page.html
+++ b/app/src/app/universities/roster-page/roster-page.html
@@ -11,8 +11,8 @@
     <header class="roster-page__header">
       <h1>{{ data.university.title }} — Rosters</h1>
       <div class="roster-page__actions">
-        <button type="button" (click)="print()">Print</button>
-        <button type="button" (click)="exportEventCsv()">Export event CSV</button>
+        <button type="button" (click)="onPrint()">Print</button>
+        <button type="button" (click)="onExportEventCsv()">Export event CSV</button>
       </div>
     </header>
 
@@ -34,7 +34,7 @@
               · {{ classRoster.class.waitlistCount }} waitlisted
             }
           </span>
-          <button type="button" (click)="exportClassCsv(classRoster)">Export CSV</button>
+          <button type="button" (click)="onExportClassCsv(classRoster)">Export CSV</button>
         </header>
 
         @if (classRoster.class.counselorNames.length > 0) {
@@ -122,5 +122,15 @@
         }
       </section>
     }
+  }
+
+  @if (showExportWarning()) {
+    <app-confirm-modal
+      title="Export contains youth information"
+      message="You are responsible for safeguarding and deleting this data per Youth Protection guidelines once you're done with it."
+      confirmLabel="I understand, continue"
+      (confirmed)="confirmExportWarning()"
+      (cancelled)="cancelExportWarning()"
+    />
   }
 </main>

--- a/app/src/app/universities/roster-page/roster-page.spec.ts
+++ b/app/src/app/universities/roster-page/roster-page.spec.ts
@@ -1,17 +1,31 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, inject, signal } from '@angular/core';
 import { provideRouter, RouterLink, RouterOutlet } from '@angular/router';
-import { render, screen } from '@testing-library/angular/zoneless';
+import { render, screen, waitFor } from '@testing-library/angular/zoneless';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { RosterResponse } from '../../api-types/registrations-api.types';
+import { Auth } from '../../services/auth';
 import { Registrations } from '../../services/registrations';
 import { Universities } from '../../services/universities';
 import { fakeResource } from '../../test-utils/fake-resource';
 import { RosterPage } from './roster-page';
 
-// Root under test: the "View rosters" link the chancellor follows (mirroring
-// the editor's link) plus the outlet its destination renders into.
+/** Minimal Auth stand-in — RosterPage only reads sessionUser() and calls ackRosterExport(). */
+function fakeAuth(rosterExportAckAt: string | null = null) {
+  const sessionUser = signal<{ rosterExportAckAt: string | null } | undefined>({
+    rosterExportAckAt,
+  });
+  return {
+    sessionUser,
+    ackRosterExport: async () => {
+      sessionUser.set({ rosterExportAckAt: '2026-07-05T00:00:00.000Z' });
+    },
+  };
+}
+
+// Root under test: the "View rosters" link the chancellor follows plus the
+// outlet its destination (and the 403 redirect target) render into.
 @Component({
   template: `
     <a routerLink="/universities/uni1/roster">View rosters</a>
@@ -102,17 +116,18 @@ const sampleRoster: RosterResponse = {
 
 describe('RosterPage', () => {
   interface SetupOptions {
-    roster?: RosterResponse;
     // The signed-in user isn't allowed to see these rosters.
     forbidden?: boolean;
+    // ISO timestamp if the user already acknowledged the export warning.
+    ackedAt?: string | null;
   }
 
-  async function setup({ roster = sampleRoster, forbidden = false }: SetupOptions = {}) {
+  async function setup({ forbidden = false, ackedAt = null }: SetupOptions = {}) {
     const rosterResource = fakeResource<RosterResponse>();
     if (forbidden) {
       rosterResource.setError(new HttpErrorResponse({ status: 403, statusText: 'Forbidden' }));
     } else {
-      rosterResource.set(roster);
+      rosterResource.set(sampleRoster);
     }
 
     const user = userEvent.setup();
@@ -122,14 +137,9 @@ describe('RosterPage', () => {
           { path: 'universities/:id/roster', component: RosterPage },
           { path: 'universities', component: DashboardStub },
         ]),
-        {
-          provide: Registrations,
-          useValue: { roster: rosterResource, openRoster: () => {} },
-        },
-        {
-          provide: Universities,
-          useValue: { flashMessage: signal<string | null>(null) },
-        },
+        { provide: Registrations, useValue: { roster: rosterResource, openRoster: () => {} } },
+        { provide: Universities, useValue: { flashMessage: signal<string | null>(null) } },
+        { provide: Auth, useValue: fakeAuth(ackedAt) },
       ],
     });
 
@@ -137,6 +147,10 @@ describe('RosterPage', () => {
       async openRosters() {
         await user.click(await screen.findByRole('link', { name: 'View rosters' }));
       },
+      async clickPrint() {
+        await user.click(screen.getByRole('button', { name: 'Print' }));
+      },
+      user,
     };
   }
 
@@ -154,6 +168,47 @@ describe('RosterPage', () => {
     expect(screen.getByRole('button', { name: 'Print' })).toBeVisible();
     expect(screen.getByRole('button', { name: 'Export event CSV' })).toBeVisible();
     expect(screen.getAllByRole('button', { name: 'Export CSV' })).toHaveLength(2);
+  });
+
+  it('shows the export-warning modal and acks it before the first export', async () => {
+    vi.spyOn(globalThis, 'print').mockImplementation(() => {});
+    const { openRosters, clickPrint } = await setup();
+    await openRosters();
+
+    expect(await screen.findByRole('heading', { name: 'Camping' })).toBeVisible();
+    await clickPrint();
+
+    expect(
+      await screen.findByRole('alertdialog', { name: /Export contains youth information/ }),
+    ).toBeVisible();
+
+    await userEvent.click(screen.getByRole('button', { name: 'I understand, continue' }));
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument());
+  });
+
+  it('skips the modal on subsequent exports once already acked', async () => {
+    vi.spyOn(globalThis, 'print').mockImplementation(() => {});
+    const { openRosters, clickPrint } = await setup({ ackedAt: '2026-07-01T00:00:00.000Z' });
+    await openRosters();
+
+    expect(await screen.findByRole('heading', { name: 'Camping' })).toBeVisible();
+    await clickPrint();
+
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+
+  it('dismisses the modal without exporting when cancelled', async () => {
+    const { openRosters, clickPrint } = await setup();
+    await openRosters();
+
+    expect(await screen.findByRole('heading', { name: 'Camping' })).toBeVisible();
+    await clickPrint();
+    expect(await screen.findByRole('alertdialog')).toBeVisible();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument());
   });
 
   it('redirects to the dashboard with a flash message when access is forbidden', async () => {

--- a/app/src/app/universities/roster-page/roster-page.ts
+++ b/app/src/app/universities/roster-page/roster-page.ts
@@ -1,15 +1,24 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  signal,
+} from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import type { ClassRoster } from '../../api-types/registrations-api.types';
 import { classRosterToCsv, eventRosterToCsv } from '../../lib/roster-csv';
+import { Auth } from '../../services/auth';
 import { Registrations } from '../../services/registrations';
 import { Universities } from '../../services/universities';
+import { ConfirmModal } from '../../shared/confirm-modal/confirm-modal';
 
 @Component({
   selector: 'app-roster-page',
-  imports: [RouterLink],
+  imports: [RouterLink, ConfirmModal],
   templateUrl: './roster-page.html',
   styleUrl: './roster-page.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -19,6 +28,7 @@ export class RosterPage {
   private readonly router = inject(Router);
   private readonly universities = inject(Universities);
   private readonly registrations = inject(Registrations);
+  private readonly auth = inject(Auth);
 
   protected readonly universityId = signal('');
 
@@ -32,6 +42,10 @@ export class RosterPage {
     if (error instanceof HttpErrorResponse && error.status === 403) return null;
     return 'Could not load rosters for this event.';
   });
+
+  protected readonly hasAckedExport = computed(() => !!this.auth.sessionUser()?.rosterExportAckAt);
+  protected readonly showExportWarning = signal(false);
+  private pendingExport: (() => void) | null = null;
 
   constructor() {
     effect(() => {
@@ -51,21 +65,51 @@ export class RosterPage {
     });
   }
 
-  protected print(): void {
-    globalThis.print();
+  protected onPrint(): void {
+    this.requestExport(() => globalThis.print());
   }
 
-  protected exportEventCsv(): void {
-    const data = this.roster.value();
-    if (!data) return;
-    this.downloadCsv(eventRosterToCsv(data), `${data.university.title} - roster.csv`);
+  protected onExportEventCsv(): void {
+    this.requestExport(() => {
+      const data = this.roster.value();
+      if (!data) return;
+      this.downloadCsv(eventRosterToCsv(data), `${data.university.title} - roster.csv`);
+    });
   }
 
-  protected exportClassCsv(classRoster: ClassRoster): void {
-    this.downloadCsv(
-      classRosterToCsv(classRoster),
-      `${classRoster.class.badgeTitle} - roster.csv`,
-    );
+  protected onExportClassCsv(classRoster: ClassRoster): void {
+    this.requestExport(() => {
+      this.downloadCsv(
+        classRosterToCsv(classRoster),
+        `${classRoster.class.badgeTitle} - roster.csv`,
+      );
+    });
+  }
+
+  private requestExport(action: () => void): void {
+    if (this.hasAckedExport()) {
+      action();
+      return;
+    }
+    this.pendingExport = action;
+    this.showExportWarning.set(true);
+  }
+
+  protected async confirmExportWarning(): Promise<void> {
+    this.showExportWarning.set(false);
+    const action = this.pendingExport;
+    this.pendingExport = null;
+    try {
+      await this.auth.ackRosterExport();
+    } catch {
+      return;
+    }
+    action?.();
+  }
+
+  protected cancelExportWarning(): void {
+    this.showExportWarning.set(false);
+    this.pendingExport = null;
   }
 
   private downloadCsv(content: string, filename: string): void {

--- a/functions/src/collections/users.ts
+++ b/functions/src/collections/users.ts
@@ -24,6 +24,8 @@ export interface UserDocument {
   acceptedPrivacyAt: Timestamp | null;
   /** POLICY_VERSION in effect when onboarding consent was accepted. */
   acceptedPolicyVersion: string | null;
+  /** Set once this chancellor/counselor has clicked through the roster-export warning. */
+  rosterExportAckAt: Timestamp | null;
   createdAt: Timestamp;
   updatedAt: Timestamp;
 }

--- a/functions/src/shared-api/services/authz/assertions.test.ts
+++ b/functions/src/shared-api/services/authz/assertions.test.ts
@@ -25,7 +25,9 @@ function readerAllowing(
 ): RoleGrantsReader {
   return {
     hasActiveGrant: ({ scopeId, role }: GrantQuery) =>
-      Promise.resolve(grants.some((g) => g.scopeId === scopeId && g.role === role)),
+      Promise.resolve(
+        grants.some(g => g.scopeId === scopeId && g.role === role),
+      ),
     listActiveClassGrants: () => Promise.resolve([]),
   };
 }
@@ -77,6 +79,16 @@ describe("assertCounselorOf", () => {
   it("rejects when neither grant exists", async () => {
     await expect(
       assertCounselorOf(caller(), scope, readerAllowing([])),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  it("rejects a counselor of a different class in the same university", async () => {
+    await expect(
+      assertCounselorOf(
+        caller(),
+        scope,
+        readerAllowing([{ scopeId: "cls2-not-cls1", role: "counselor" }]),
+      ),
     ).rejects.toBeInstanceOf(ForbiddenError);
   });
 

--- a/functions/src/users-api/app.test.ts
+++ b/functions/src/users-api/app.test.ts
@@ -35,6 +35,7 @@ const usersService: UsersService = {
         acceptedTermsAt: null,
         acceptedPrivacyAt: null,
         acceptedPolicyVersion: null,
+        rosterExportAckAt: null,
       },
       needsConsent: true,
     }),
@@ -47,6 +48,7 @@ const usersService: UsersService = {
       acceptedTermsAt: null,
       acceptedPrivacyAt: null,
       acceptedPolicyVersion: null,
+      rosterExportAckAt: null,
     }),
   onboard: (caller, request) =>
     Promise.resolve({
@@ -57,6 +59,18 @@ const usersService: UsersService = {
       acceptedTermsAt: "2026-07-03T00:00:00.000Z",
       acceptedPrivacyAt: "2026-07-03T00:00:00.000Z",
       acceptedPolicyVersion: "2026-07-04",
+      rosterExportAckAt: null,
+    }),
+  ackRosterExport: caller =>
+    Promise.resolve({
+      uid: caller.uid,
+      displayName: "Pat",
+      email: caller.email,
+      phone: null,
+      acceptedTermsAt: "2026-07-03T00:00:00.000Z",
+      acceptedPrivacyAt: "2026-07-03T00:00:00.000Z",
+      acceptedPolicyVersion: "2026-07-04",
+      rosterExportAckAt: "2026-07-05T00:00:00.000Z",
     }),
   deleteAccount: () => Promise.resolve(),
 };
@@ -221,5 +235,17 @@ describe("users-api routes", () => {
     expect(response.status).toBe(403);
     const body = (await response.json()) as { code?: string };
     expect(body.code).toBe(ERROR_CODES.CLOSE_EVENTS_FIRST);
+  });
+
+  it("POST /api/users/me/roster-export-ack stamps rosterExportAckAt", async () => {
+    const response = await handleRequest(
+      app(),
+      authed("/api/users/me/roster-export-ack", "POST"),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      rosterExportAckAt: string | null;
+    };
+    expect(body.rosterExportAckAt).not.toBeNull();
   });
 });

--- a/functions/src/users-api/app.ts
+++ b/functions/src/users-api/app.ts
@@ -46,6 +46,11 @@ export function createApp(services?: PartialUsersApiServices) {
       await users.deleteAccount(caller);
       set.status = 204;
     })
+    .post(
+      "/users/me/roster-export-ack",
+      ({ caller }) => users.ackRosterExport(caller),
+      { response: UserResponseSchema },
+    )
     .get("/users/me/scouts", ({ caller }) => scouts.list(caller), {
       response: ScoutListResponseSchema,
     })

--- a/functions/src/users-api/schemas/user-schemas.ts
+++ b/functions/src/users-api/schemas/user-schemas.ts
@@ -9,6 +9,7 @@ export const UserResponseSchema = t.Object({
   acceptedTermsAt: t.Union([t.String(), t.Null()]),
   acceptedPrivacyAt: t.Union([t.String(), t.Null()]),
   acceptedPolicyVersion: t.Union([t.String(), t.Null()]),
+  rosterExportAckAt: t.Union([t.String(), t.Null()]),
 });
 export type UserResponse = Static<typeof UserResponseSchema>;
 

--- a/functions/src/users-api/services/users/index.ts
+++ b/functions/src/users-api/services/users/index.ts
@@ -50,6 +50,7 @@ function toUserResponse(uid: string, doc: UserDocument): UserResponse {
     acceptedTermsAt: toIso(doc.acceptedTermsAt),
     acceptedPrivacyAt: toIso(doc.acceptedPrivacyAt),
     acceptedPolicyVersion: doc.acceptedPolicyVersion ?? null,
+    rosterExportAckAt: toIso(doc.rosterExportAckAt),
   };
 }
 
@@ -84,6 +85,7 @@ export class UsersServiceImpl implements UsersService {
         acceptedTermsAt: null,
         acceptedPrivacyAt: null,
         acceptedPolicyVersion: null,
+        rosterExportAckAt: null,
         createdAt: FieldValue.serverTimestamp(),
         updatedAt: FieldValue.serverTimestamp(),
       });
@@ -195,6 +197,28 @@ export class UsersServiceImpl implements UsersService {
     // re-bootstraps a blank doc), never orphaned PII.
     await this.db().collection(USERS_COLLECTION).doc(caller.uid).delete();
     await this.authAdmin.deleteUser(caller.uid);
+  }
+
+  async ackRosterExport(caller: Caller): Promise<UserResponse> {
+    const reference = this.db().collection(USERS_COLLECTION).doc(caller.uid);
+    const snapshot = await reference.get();
+    if (!snapshot.exists) {
+      throw new NotFoundError("User not found");
+    }
+    const existing = snapshot.data() as UserDocument;
+    if (existing.rosterExportAckAt === null) {
+      await reference.set(
+        {
+          rosterExportAckAt: FieldValue.serverTimestamp(),
+          updatedAt: FieldValue.serverTimestamp(),
+        },
+        { merge: true },
+      );
+    }
+    return toUserResponse(
+      caller.uid,
+      (await reference.get()).data() as UserDocument,
+    );
   }
 
   /**

--- a/functions/src/users-api/services/users/interface.ts
+++ b/functions/src/users-api/services/users/interface.ts
@@ -17,6 +17,7 @@ export interface UsersService {
   /** Record displayName + Terms/Privacy consent timestamps. */
   onboard(caller: Caller, request: OnboardingRequest): Promise<UserResponse>;
   /**
+  /**
    * Right-to-erasure: deletes every owned scout (cascading their active
    * registrations), revokes active counselor grants, deletes the user doc,
    * and deletes the Firebase Auth user. Blocked while the caller holds an
@@ -24,4 +25,9 @@ export interface UsersService {
    * close or draft it first.
    */
   deleteAccount(caller: Caller): Promise<void>;
+  /**
+   * Stamps rosterExportAckAt the first time a chancellor/counselor clicks
+   * through the roster-export warning. Idempotent — first-write-wins.
+   */
+  ackRosterExport(caller: Caller): Promise<UserResponse>;
 }


### PR DESCRIPTION
## Summary
- PR 4 (final) of the youth-data-privacy plan (issue #88): a one-time acknowledgment before a chancellor/counselor's first roster export, plus explicit negative-case authz coverage closing part of the gap issue #97 gestures at.
- `collections/users.ts` gains `rosterExportAckAt: Timestamp | null`; new `POST /users/me/roster-export-ack` + `UsersService.ackRosterExport(caller)` stamps it idempotently (first-write-wins); surfaced on `GET /users/me`/bootstrap so the client knows whether the modal is still required.
- New reusable `ConfirmModal` under `app/src/app/shared/` — the app previously had no dialog component, only native `confirm()`/inline prompts.
- `RosterPage` gates `print()`/`exportEventCsv()`/`exportClassCsv()` behind the modal on first use ("You are responsible for safeguarding and deleting this data per Youth Protection guidelines…"); confirming calls the ack endpoint then proceeds; already-acked sessions skip the modal entirely (`Auth.sessionUser()?.rosterExportAckAt`, updated in place after ack so no re-bootstrap is needed).
- Adds an explicit `assertCounselorOf` negative-case test (counselor of class A rejected for class B) — the other two scenarios the plan named (non-grantee → 403, parent reads only own scouts) were already covered by existing tests in `assertions.test.ts`, just not obviously labeled.
- Per `testing-philosophy.md` ("don't test the service layer directly"), the roster-filtering *composition* (which classes a counselor actually sees back from `listRoster`) is proven only indirectly — via the already-tested authz primitives plus the existing boundary test that a service-thrown `ForbiddenError` maps to 403 — not via a new integration/service-level test.

## Test plan
- [x] `cd functions && bun test` — 133 pass, including the new `assertCounselorOf` cross-class case and the `roster-export-ack` boundary test
- [x] `cd app && bun run test` — 64 pass, including new `roster-page.spec.ts` coverage: modal shown + acked on first export, skipped once already acked, dismissible via cancel with no export/ack side effect
- [x] `tsc --noEmit` clean in both `functions` and `app`
- [x] `eslint` clean on changed frontend files
- [ ] Manual/emulator smoke test not performed (same limitation as PR1–PR3 — no seed harness in this repo)

## Sequencing note
This is the last of the 4 sequenced PRs for issue #88 (#116 merged, #117 and #118 open). Each branched independently off trunk per the plan's "independently shippable" framing, so expect the usual small merge-order conflicts (e.g. `collections/users.ts`, `users-api/app.test.ts`) when landing after #117.