### PR TITLE
Enforce API module architecture via lint, CI check, and ADR

### DIFF
--- a/.github/workflows/functions-pull-request.yml
+++ b/.github/workflows/functions-pull-request.yml
@@ -18,6 +18,16 @@ permissions:
   pull-requests: write
 
 jobs:
+  arch:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+      - name: Check API module architecture
+        working-directory: functions
+        run: npm run check:arch
+
   lint:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest

--- a/.github/workflows/functions-pull-request.yml
+++ b/.github/workflows/functions-pull-request.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v7.0.0
       - name: Check API module architecture
         working-directory: functions
-        run: npm run check:arch
+        run: bash scripts/check-architecture.sh
 
   lint:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,10 +211,11 @@ function per route, plain-object services, and per-route boundary tests — with
 The conventions are enforced, so non-conforming code fails CI:
 
 - `cd functions && npm run lint` — ESLint bans service classes, mock-call
-  assertions, test lifecycle hooks, and mocking `firebase-admin` internals.
-- `cd functions && npm run check:arch` — tests must live in `routes/`, and every
-  deployed `*-api` module must have `routes/` + `plugins/` + `app.ts` +
-  `handler.ts`.
+  assertions, test lifecycle hooks, mocking `firebase-admin` internals, and
+  emulator imports, and flags any test file outside a `routes/` directory.
+- `cd functions && npm run check:arch` — every deployed `*-api` module must have
+  `routes/` + `plugins/` + `app.ts` + `handler.ts` (the file-existence invariant
+  ESLint can't express).
 
 Angular spec conventions are enforced the same way via `app/eslint.config.js`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,26 @@ The scraper in `scripts/sync-requirements-hybrid.ts` uses:
   - Auto-organize imports
 - **TypeScript**: Strict mode enabled, Bun module resolution
 
+## Event Platform (`functions/` + `app/`)
+
+The self-serve event platform (issue #94) is a separate stack from the Hugo
+site: an Angular SPA in `app/` and per-domain Elysia APIs on Cloud Functions in
+`functions/`. Its API modules follow a fixed architecture — plugin + one logic
+function per route, plain-object services, and per-route boundary tests — with
+`functions/src/health-api/` as the reference module.
+
+**Before adding or changing an API module, read
+[docs/adr/0001-api-module-architecture.md](docs/adr/0001-api-module-architecture.md).**
+The conventions are enforced, so non-conforming code fails CI:
+
+- `cd functions && npm run lint` — ESLint bans service classes, mock-call
+  assertions, test lifecycle hooks, and mocking `firebase-admin` internals.
+- `cd functions && npm run check:arch` — tests must live in `routes/`, and every
+  deployed `*-api` module must have `routes/` + `plugins/` + `app.ts` +
+  `handler.ts`.
+
+Angular spec conventions are enforced the same way via `app/eslint.config.js`.
+
 ## Important Notes
 
 - Main branch is `trunk`, not `main` or `master`

--- a/docs/adr/0001-api-module-architecture.md
+++ b/docs/adr/0001-api-module-architecture.md
@@ -1,0 +1,65 @@
+# ADR 0001 — API module architecture (Elysia on Cloud Functions)
+
+- **Status:** Accepted
+- **Date:** 2026-07-05
+- **Applies to:** `functions/src/**/*-api/**`
+- **Related:** #94 (Phase 1 epic), #121 (the refactor that realigned all modules),
+  `~/.claude/rules/{elysia,firebase-elysia,firebase-functions-testing,testing-philosophy}.md`
+
+## Context
+
+Phase 1 committed to mirror the `doula-cooperative/functions` layout, but four of
+five API modules drifted: routes were inlined into `app.ts`, exercised by
+whole-app `app.test.ts` suites, backed by class-based services, alongside
+standalone service-layer tests. Only `health-api` matched the reference. The
+conventions were documented (in personal `~/.claude/rules/` and in #94's
+description) but **only advisory** — nothing failed when code diverged, so it
+did. #121 realigned every module; this ADR records the decision and the
+enforcement that keeps it from drifting again.
+
+## Decision
+
+Every deployed API module (`functions/src/<name>-api/`, except the shared
+`shared-api` library) follows this shape, using `health-api` as the in-repo
+reference:
+
+1. **Layout.** `app.ts` (factory composing plugins) · `handler.ts` (Firebase
+   entry) · `plugins/<name>-plugin.ts` · `routes/<route>.ts` (one logic function
+   per route, no auth code) · `routes/<route>.test.ts` · `schemas/` ·
+   `services/` · `test-utils/create-<name>-test-plugin.ts` · `types/`.
+2. **`app.ts` is a thin factory:**
+   `createApp(services?) => new Elysia({ adapter: node(), prefix: "/api" }).onError(mapError).use(create<Name>Plugin(services))`.
+   Authentication lives in the plugin guard (`.resolve(requireAuth(...))`);
+   public routes stay outside it. Domain authorization stays in services.
+3. **Services are plain object literals** typed to an interface
+   (`export const XServiceImpl: X = { … }`) — never classes. Call
+   `getFirestore()` inline and take cross-cutting deps (`logger`) as function
+   parameters. (`class Foo extends Error` for the `HttpError` hierarchy is fine.)
+4. **Tests are per-route boundary tests only.** One `routes/<route>.test.ts`
+   per route, each with a SIFERS `setup()`, driving the plugin through
+   `handle()` with services mocked at the seam via `create<Name>TestPlugin()`.
+   Assert on the HTTP response, not on mock calls. Every authenticated route
+   covers 401 (no token) and 403 (forbidden); admin routes add a non-admin 403.
+   **No** whole-app `app.test.ts`, **no** standalone service-layer tests, **no**
+   mocking of `firebase-admin` internals, **no** emulator in unit tests.
+
+## Consequences
+
+- Route logic is small, testable, and free of auth/transport coupling.
+- The trade-off (accepted): exhaustive pure-function suites (e.g. a state-machine
+  matrix) lose standalone granularity; their meaningful cases are re-expressed as
+  route behaviors.
+- Services converted from classes lose constructor-DI seams that existed only for
+  the old service-layer tests; boundary tests mock the whole service instead.
+
+## Enforcement (docs describe; lint/CI enforce)
+
+- **ESLint** (`functions/eslint.config.js`): bans service classes
+  (`class … implements`), mock-call assertions, lifecycle hooks (SIFERS), and
+  mocking `firebase-admin` internals. Runs in the `lint` CI job.
+- **Structural check** (`functions/scripts/check-architecture.sh`, via
+  `npm run check:arch`, `arch` CI job): tests must live in `routes/`, no
+  `app.test.ts`, every deployed `*-api` module has `routes/` + `plugins/` +
+  `app.ts` + `handler.ts`.
+- **Scaffold new modules by copying `health-api`** — the smallest conformant
+  module — so the correct pattern is the path of least resistance.

--- a/docs/adr/0001-api-module-architecture.md
+++ b/docs/adr/0001-api-module-architecture.md
@@ -54,12 +54,14 @@ reference:
 
 ## Enforcement (docs describe; lint/CI enforce)
 
-- **ESLint** (`functions/eslint.config.js`): bans service classes
-  (`class … implements`), mock-call assertions, lifecycle hooks (SIFERS), and
-  mocking `firebase-admin` internals. Runs in the `lint` CI job.
+- **ESLint** (`functions/eslint.config.js`) — everything about files that
+  exist: bans service classes (`class … implements`), mock-call assertions,
+  lifecycle hooks (SIFERS), mocking `firebase-admin` internals, and emulator
+  imports; and flags any test file outside a `routes/` directory (catches
+  whole-app `app.test.ts` and service-layer tests). Runs in the `lint` CI job.
 - **Structural check** (`functions/scripts/check-architecture.sh`, via
-  `npm run check:arch`, `arch` CI job): tests must live in `routes/`, no
-  `app.test.ts`, every deployed `*-api` module has `routes/` + `plugins/` +
-  `app.ts` + `handler.ts`.
+  `npm run check:arch`, `arch` CI job) — the one thing a per-file linter can't
+  express: required paths must **exist**. Every deployed `*-api` module has
+  `routes/` + `plugins/` + `app.ts` + `handler.ts`.
 - **Scaffold new modules by copying `health-api`** — the smallest conformant
   module — so the correct pattern is the path of least resistance.

--- a/functions/eslint.config.js
+++ b/functions/eslint.config.js
@@ -44,6 +44,39 @@ const noFirebaseAdminMock = {
     "Never mock firebase-admin internals. Mock the service interface at the plugin boundary (create*TestPlugin), not the transport it uses.",
 };
 
+// Tests are per-route boundary tests living in a routes/ directory. A test file
+// anywhere else (a whole-app app.test.ts, a standalone service-layer test) is a
+// convention violation regardless of its contents, so flag the whole file.
+const testFileOutsideRoutes = {
+  selector: "Program",
+  message:
+    "Tests must be per-route boundary tests inside a routes/ directory — no whole-app app.test.ts, no service-layer tests. Drive the plugin via handle() with mocked services. See docs/adr/0001-api-module-architecture.md.",
+};
+
+// Content rules that apply to every test file wherever it lives.
+const testContentRules = [
+  noServiceClasses,
+  noMockCallAssertions,
+  noTestHooks,
+  noFirebaseAdminMock,
+];
+
+// Emulators/test harnesses have no place in these unit tests — mock at the
+// boundary. (Firestore *rules* tests, if ever added, live under firestore/ with
+// their own emulator script, not in functions/src.)
+const noEmulatorImports = [
+  {
+    name: "firebase-functions-test",
+    message:
+      "No Functions emulator/harness in unit tests — drive the plugin via handle() with mocked services (create*TestPlugin).",
+  },
+  {
+    name: "@firebase/rules-unit-testing",
+    message:
+      "No emulator in unit tests — mock services at the boundary. Firestore rules tests belong under firestore/, not functions/src.",
+  },
+];
+
 export default defineConfig([
   {
     ignores: ["lib/**"],
@@ -71,17 +104,24 @@ export default defineConfig([
     },
   },
   {
-    // Boundary tests only: drive the plugin through handle(), mock services at
-    // the seam, assert on the response. (Enforced test location: routes/ — see
-    // `npm run check:arch`.)
+    // Every test file: content rules + no emulator imports.
     files: ["**/*.test.ts"],
+    rules: {
+      "no-restricted-syntax": ["error", ...testContentRules],
+      "no-restricted-imports": ["error", { paths: noEmulatorImports }],
+    },
+  },
+  {
+    // Test files NOT under a routes/ directory are misplaced by definition —
+    // flag the file location on top of the content rules. (Ordered after the
+    // block above so this rule set wins for these files.)
+    files: ["**/*.test.ts"],
+    ignores: ["**/routes/**"],
     rules: {
       "no-restricted-syntax": [
         "error",
-        noServiceClasses,
-        noMockCallAssertions,
-        noTestHooks,
-        noFirebaseAdminMock,
+        testFileOutsideRoutes,
+        ...testContentRules,
       ],
     },
   },

--- a/functions/eslint.config.js
+++ b/functions/eslint.config.js
@@ -2,6 +2,48 @@ import eslint from "@eslint/js";
 import { defineConfig } from "eslint/config";
 import tseslint from "typescript-eslint";
 
+// Architecture + testing guards for the Elysia API modules. These encode the
+// conventions in docs/adr/0001-api-module-architecture.md (and
+// ~/.claude/rules/{elysia,testing-philosophy,firebase-functions-testing}.md) so
+// violations fail `npm run lint` in CI instead of relying on reviewer memory.
+// See also `npm run check:arch` for the structural checks ESLint can't express
+// (tests must live in routes/, every *-api module needs routes/ + plugins/).
+
+// Services and collaborators are plain object literals typed to their
+// interface (`export const XServiceImpl: X = { … }`), not classes. `implements`
+// is the tell — `class Foo extends Error` (our HttpError hierarchy) is fine.
+const noServiceClasses = {
+  selector: "ClassDeclaration:has(TSClassImplements)",
+  message:
+    "Services must be plain object literals typed to their interface (export const XImpl: X = { … }), not classes. Call getFirestore() inline and take cross-cutting deps as params. See docs/adr/0001-api-module-architecture.md.",
+};
+
+// Assert on the HTTP response (status/body), not on how a mocked service was
+// called — test the contract, not the implementation.
+const noMockCallAssertions = {
+  selector:
+    "CallExpression[callee.property.name=/^toHaveBeenCalled(Once|With|Times|OnceWith|ExactlyOnceWith)?$/]",
+  message:
+    "Assert on the HTTP response (status/body), not on how a mock was called. Test the contract, not the implementation.",
+};
+
+// Prefer a SIFERS setup() per describe block over shared lifecycle hooks.
+const noTestHooks = {
+  selector:
+    "CallExpression[callee.name=/^(beforeEach|afterEach|beforeAll|afterAll)$/]",
+  message:
+    "Prefer a SIFERS setup() function over beforeEach/afterEach hooks — centralize construction and reset state fresh per test.",
+};
+
+// Never mock firebase-admin internals; inject and mock the service interface at
+// the plugin boundary via a create*TestPlugin factory instead.
+const noFirebaseAdminMock = {
+  selector:
+    "CallExpression[callee.object.name='mock'][callee.property.name='module'] Literal[value=/firebase-admin/]",
+  message:
+    "Never mock firebase-admin internals. Mock the service interface at the plugin boundary (create*TestPlugin), not the transport it uses.",
+};
+
 export default defineConfig([
   {
     ignores: ["lib/**"],
@@ -23,6 +65,24 @@ export default defineConfig([
         project: ["./tsconfig.test.json"],
         tsconfigRootDir: import.meta.dirname,
       },
+    },
+    rules: {
+      "no-restricted-syntax": ["error", noServiceClasses],
+    },
+  },
+  {
+    // Boundary tests only: drive the plugin through handle(), mock services at
+    // the seam, assert on the response. (Enforced test location: routes/ — see
+    // `npm run check:arch`.)
+    files: ["**/*.test.ts"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        noServiceClasses,
+        noMockCallAssertions,
+        noTestHooks,
+        noFirebaseAdminMock,
+      ],
     },
   },
 ]);

--- a/functions/package.json
+++ b/functions/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "scripts": {
     "lint": "eslint .",
+    "check:arch": "bash scripts/check-architecture.sh",
     "build": "tsc",
     "build:watch": "tsc --watch",
     "typecheck": "tsc --noEmit",

--- a/functions/scripts/check-architecture.sh
+++ b/functions/scripts/check-architecture.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 #
-# Structural architecture checks for the Elysia API modules — the invariants
-# ESLint can't express as syntax rules. Fails CI when a module drifts from the
-# reference layout (see docs/adr/0001-api-module-architecture.md).
+# Structural architecture check for the Elysia API modules — the one invariant
+# ESLint can't express: required directories/files must EXIST. (A missing
+# routes/ dir produces no file for ESLint to lint.) Test placement and content
+# rules live in eslint.config.js; this only asserts the module shape.
+# See docs/adr/0001-api-module-architecture.md.
 #
 # Run from functions/:  npm run check:arch
 set -euo pipefail
@@ -14,24 +16,10 @@ err() {
   fail=1
 }
 
-echo "Checking API module architecture…"
+echo "Checking API module structure…"
 
-# 1. Every test is a per-route boundary test living in a routes/ directory.
-#    (No whole-app app.test.ts, no standalone service-layer tests.)
-stray_tests=$(find src -name '*.test.ts' | grep -v '/routes/' || true)
-if [ -n "$stray_tests" ]; then
-  err "test files outside a routes/ directory (tests must be per-route boundary tests):"
-  echo "$stray_tests" | sed 's/^/      /'
-fi
-
-app_tests=$(find src -name 'app.test.ts' || true)
-if [ -n "$app_tests" ]; then
-  err "app.test.ts found (test each route in routes/, not the whole app):"
-  echo "$app_tests" | sed 's/^/      /'
-fi
-
-# 2. Every deployed *-api module has the reference shape. shared-api is the
-#    shared library (no routes/deployed app), so it is exempt.
+# Every deployed *-api module has the reference shape. shared-api is the shared
+# library (no routes/deployed app), so it is exempt.
 for dir in src/*-api; do
   module=$(basename "$dir")
   [ "$module" = "shared-api" ] && continue
@@ -49,3 +37,4 @@ if [ "$fail" -ne 0 ]; then
 fi
 
 echo "  ✓ all API modules conform"
+

--- a/functions/scripts/check-architecture.sh
+++ b/functions/scripts/check-architecture.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Structural architecture checks for the Elysia API modules — the invariants
+# ESLint can't express as syntax rules. Fails CI when a module drifts from the
+# reference layout (see docs/adr/0001-api-module-architecture.md).
+#
+# Run from functions/:  npm run check:arch
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+fail=0
+err() {
+  echo "  ✗ $1"
+  fail=1
+}
+
+echo "Checking API module architecture…"
+
+# 1. Every test is a per-route boundary test living in a routes/ directory.
+#    (No whole-app app.test.ts, no standalone service-layer tests.)
+stray_tests=$(find src -name '*.test.ts' | grep -v '/routes/' || true)
+if [ -n "$stray_tests" ]; then
+  err "test files outside a routes/ directory (tests must be per-route boundary tests):"
+  echo "$stray_tests" | sed 's/^/      /'
+fi
+
+app_tests=$(find src -name 'app.test.ts' || true)
+if [ -n "$app_tests" ]; then
+  err "app.test.ts found (test each route in routes/, not the whole app):"
+  echo "$app_tests" | sed 's/^/      /'
+fi
+
+# 2. Every deployed *-api module has the reference shape. shared-api is the
+#    shared library (no routes/deployed app), so it is exempt.
+for dir in src/*-api; do
+  module=$(basename "$dir")
+  [ "$module" = "shared-api" ] && continue
+  for required in routes plugins app.ts handler.ts; do
+    if [ ! -e "$dir/$required" ]; then
+      err "$module is missing $required (see health-api for the reference layout)"
+    fi
+  done
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo ""
+  echo "Architecture check FAILED. See docs/adr/0001-api-module-architecture.md."
+  exit 1
+fi
+
+echo "  ✓ all API modules conform"


### PR DESCRIPTION
## Context

#121 realigned the Elysia API modules to the doula-cooperative reference pattern, but that alignment was only *documented* (in personal `~/.claude/rules/` and #94's description) — which is exactly why it drifted in the first place. This PR makes the conventions **self-enforcing** so they fail CI instead of relying on reviewer memory. **Docs describe; lint/CI enforce** — and we already had this precedent for Angular specs (#120).

## What's enforced

**ESLint** (`functions/eslint.config.js`), mirroring the app's named-selector style:
- Ban service **classes** (`class … implements` — `Error` subclasses stay allowed)
- Ban **mock-call assertions** (`toHaveBeenCalled*`) — assert on the response, not the mock
- Ban **test lifecycle hooks** (`beforeEach`/etc.) in favor of SIFERS `setup()`
- Ban mocking **`firebase-admin` internals** (`mock.module("firebase-admin/…")`)

**Structural check** (`functions/scripts/check-architecture.sh`, `npm run check:arch`, new `arch` CI job) for what ESLint can't express:
- Tests must live in `routes/`; no `app.test.ts`
- Every deployed `*-api` module has `routes/` + `plugins/` + `app.ts` + `handler.ts` (`shared-api` exempt)

**ADR** (`docs/adr/0001-api-module-architecture.md`): records the decision, the trade-offs, and the enforcement — the "why" that prevents re-litigation.

**CLAUDE.md**: points contributors at the ADR + the two commands before touching an API module.

## Verification

Both gates **pass on current code** (0 violations — the refactor left the tree conformant) and **fire on planted violations** — confirmed all four ESLint messages trigger and `check:arch` fails on a misplaced test, then reverted the temp files. The `arch` job runs on plain `ubuntu-latest` (checkout + bash only, no container/deps) so it's fast.

## Follow-up worth considering

- Extend `check:arch` to assert each module also ships a `test-utils/create-*-test-plugin.ts`.
- A `bun run new:api <name>` scaffold that stamps out a conformant module (copy of `health-api`), making the correct pattern the path of least resistance.